### PR TITLE
Fix 'wrong number of arguments' bug with Capybara-Webkit

### DIFF
--- a/lib/billy/rspec.rb
+++ b/lib/billy/rspec.rb
@@ -46,7 +46,7 @@ end
 
 if defined?(Capybara::Driver::Webkit)
   Capybara.register_driver :webkit_billy do |app|
-    driver = Capybara::Driver::Webkit.new(app)
+    driver = Capybara::Webkit::Driver.new(app)
     driver.browser.set_proxy(:host => Billy.proxy.host,
                              :port => Billy.proxy.port)
     driver.browser.ignore_ssl_errors


### PR DESCRIPTION
Fix bug with driver initialisation when using Capybara-Webkit
