### PR TITLE
Remove require from Gemfile example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can also record HTTP interactions and replay them later. See
 
 Add this line to your application's Gemfile:
 
-    gem 'puffing-billy', :require => 'billy'
+    gem 'puffing-billy'
 
 And then execute:
 


### PR DESCRIPTION
Having bundler require 'billy' from the Gemfile caused billy to be loaded after the `Rails` constant was available but before `Rails.logger` was assigned.  This had the effect of breaking billy's logging.

Note: Removing the require is functionally the same as `require: false` because of the project's name vs lib path.
