### PR TITLE
Add Capybara.server_port to spec_helper example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ require 'billy/rspec'
 Capybara.javascript_driver = :selenium_billy
 # Capybara.javascript_driver = :webkit_billy
 # Capybara.javascript_driver = :poltergeist_billy
+
+# set the capybara server port
+Capybara.server_port = 7787
 ```
 
 In your tests:


### PR DESCRIPTION
My browser based 302 redirects were failing with billy until I figured out that my VCR cassettes had the randomly chosen capybara server_port burned into them.  Once I set `Capybara.server_port` to a constant value, my subsequent tests played back from those cassettes worked just fine.

Context:  I discovered while playing with billy that I could disable billy's cache because VCR could now see all of my capybara-webkit browser requests.
