### PR TITLE
Set the proxy for the webkit driver on each test run

### DIFF
--- a/lib/billy/cucumber.rb
+++ b/lib/billy/cucumber.rb
@@ -14,6 +14,14 @@ end
 
 World(Billy::CucumberHelper)
 
+Before('@billy') do
+  if Capybara.current_driver == :webkit_billy
+    Capybara.page.driver.browser.set_proxy(
+      :host => Billy.proxy.host,
+      :port => Billy.proxy.port)
+  end
+end
+
 After('@billy') do
   proxy.reset
 end

--- a/lib/billy/rspec.rb
+++ b/lib/billy/rspec.rb
@@ -15,6 +15,14 @@ end
 RSpec.configure do |config|
   config.include(Billy::RspecHelper)
 
+  config.before(:each) do
+    if Capybara.current_driver == :webkit_billy
+      Capybara.page.driver.browser.set_proxy(
+        :host => Billy.proxy.host,
+        :port => Billy.proxy.port)
+    end
+  end
+
   config.after(:each) do
     proxy.reset
   end

--- a/spec/features/poltergeist_spec.rb
+++ b/spec/features/poltergeist_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'using the poltergeist driver', :type => :feature do
+  before do
+    Capybara.current_driver = :poltergeist_billy
+  end
+
+  it_behaves_like 'stubbing the Facebook API'
+  it_behaves_like 'stubbing the Tumblr API'
+end

--- a/spec/features/webkit_spec.rb
+++ b/spec/features/webkit_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'using the webkit driver', :type => :feature do
+  before do
+    Capybara.current_driver = :webkit_billy
+  end
+
+  it_behaves_like 'stubbing the Facebook API'
+  it_behaves_like 'stubbing the Tumblr API'
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@ require 'rack'
 require 'logger'
 
 Capybara.app = Rack::Directory.new(File.expand_path("../../examples", __FILE__))
-Capybara.javascript_driver = :poltergeist_billy
 
 Billy.configure do |config|
   config.logger = Logger.new(File.expand_path("../../log/test.log", __FILE__))

--- a/spec/support/facebook_api.rb
+++ b/spec/support/facebook_api.rb
@@ -1,7 +1,6 @@
-require 'spec_helper'
 require 'base64'
 
-describe 'Facebook API example', :type => :feature, :js => true do
+shared_examples 'stubbing the Facebook API' do
   before do
     proxy.stub('https://www.facebook.com:443/dialog/oauth').and_return(Proc.new { |params,_,_|
       # mock a signed request from facebook.  the JS api never verifies the

--- a/spec/support/tumblr_api.rb
+++ b/spec/support/tumblr_api.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe 'Tumblr API example', :type => :feature, :js => true do
+shared_examples 'stubbing the Tumblr API' do
   before do
     proxy.stub('http://blog.howmanyleft.co.uk/api/read/json').and_return(
       :jsonp => {


### PR DESCRIPTION
A potential fix for issue #11. It looks like the proxy is cleared between each spec. Setting it in a before block seems to fix the issue -- the requests are routed through the proxy for each test.
