### PR TITLE
Catch invalid URI exceptions to support http://:0 URLs

### DIFF
--- a/lib/billy/proxy.rb
+++ b/lib/billy/proxy.rb
@@ -33,7 +33,11 @@ module Billy
     def call(method, url, headers, body)
       stub = find_stub(method, url)
       unless stub.nil?
-        query_string = URI.parse(url).query || ""
+        begin
+          query_string = URI.parse(url).query || ""
+        rescue URI::InvalidURIError
+          query_string = ""
+        end
         params = CGI.parse(query_string)
         stub.call(params, headers, body)
       end

--- a/lib/billy/proxy.rb
+++ b/lib/billy/proxy.rb
@@ -33,10 +33,10 @@ module Billy
     def call(method, url, headers, body)
       stub = find_stub(method, url)
       unless stub.nil?
-        begin
-          query_string = URI.parse(url).query || ""
-        rescue URI::InvalidURIError
+        if url =~ /^http:\/\/:0/
           query_string = ""
+        else
+          query_string = URI.parse(url).query || ""
         end
         params = CGI.parse(query_string)
         stub.call(params, headers, body)


### PR DESCRIPTION
For img tags, since some browsers block if you leave the src attributes empty, the current technique is to use //:0 as the URL. This causes puffing billy to fail, even when these requests are stubbed, since the URI library throws an exception. This statement has a fallback of empty string anyway, so catch exceptions and use the fallback.

I totally understand if you choose not to merge this since it's potentially introducing silent failures when people specify invalid URIs but didn't mean to.

Also, I tried to write a test for this, but it turns out faraday uses URI for parsing too, so it throws errors. [Faraday now (well, in the 0.9.0rcs) allows you to specify a less strict URI parser](https://github.com/lostisland/faraday/issues/258) like Addressable::URI, but when I tried to upgrade faraday to 0.9.0.rc6 I got ``undefined method `keepalive=' for #<Faraday::ConnectionOptions:0x007fe95564a0a0>`` which looks like something to do with the way faraday is interacting with `EventMachine` and I got frustrated.
