### PR TITLE
Set the minimum version of capybara-webkit to 1.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
       rack-test (>= 0.5.4)
       selenium-webdriver (~> 2.0)
       xpath (~> 1.0.0)
-    capybara-webkit (0.14.2)
+    capybara-webkit (1.0.0)
       capybara (~> 2.0, >= 2.0.2)
       json
     childprocess (0.3.8)
@@ -59,7 +59,7 @@ GEM
       terminal-table (>= 1.4.3)
       thor (>= 0.14.6)
     http_parser.rb (0.5.3)
-    json (1.7.7)
+    json (1.8.1)
     listen (0.7.3)
     lumberjack (1.0.2)
     method_source (0.8.1)
@@ -109,7 +109,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  capybara-webkit
+  capybara-webkit (~> 1.0)
   cucumber
   faraday
   guard

--- a/puffing-billy.gemspec
+++ b/puffing-billy.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "faraday"
   gem.add_development_dependency "poltergeist"
   gem.add_development_dependency "selenium-webdriver"
-  gem.add_development_dependency "capybara-webkit"
+  gem.add_development_dependency "capybara-webkit", "~> 1.0"
   gem.add_development_dependency "rack"
   gem.add_development_dependency "guard"
   gem.add_development_dependency "rb-inotify"


### PR DESCRIPTION
This prevents proxying issues when using the webkit-billy JS driver.

From #20, fixes issue #11.
