### PR TITLE
remove duplicated rspec devel dependency

### DIFF
--- a/puffing-billy.gemspec
+++ b/puffing-billy.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rack"
   gem.add_development_dependency "guard"
   gem.add_development_dependency "rb-inotify"
-  gem.add_development_dependency "rspec"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "cucumber"
   gem.add_runtime_dependency "eventmachine"


### PR DESCRIPTION
When installing billy/master using Bundler, it raises the following warning:

```
puffing-billy at /home/…/puffing-billy-382f9a407315 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect
its functionality.
The validation message from Rubygems was:
  duplicate dependency on rspec (>= 0, development), (>= 0) use:
    add_runtime_dependency 'rspec', '>= 0', '>= 0'
Using puffing-billy (0.2.2) from git://github.com/oesmith/puffing-billy.git (at master)
```

I presume the attached patch should fix the issue.
