### PR TITLE
Fixing a bug where proxy to SSL can duplicate https in the request_url

### DIFF
--- a/lib/billy/proxy_connection.rb
+++ b/lib/billy/proxy_connection.rb
@@ -35,7 +35,8 @@ module Billy
         restart_with_ssl(@parser.request_url)
       else
         if @ssl
-          @url = "https://#{@ssl}#{@parser.request_url}"
+          uri = URI.parse(@parser.request_url)
+          @url = "https://#{@ssl}#{[uri.path,uri.query].compact.join('?')}"
         else
           @url = @parser.request_url
         end


### PR DESCRIPTION
```
URI::InvalidURIError
the scheme https does not accept registry part: ws2.responsys.net:443https: (or bad hostname?)
/usr/local/var/rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/uri/generic.rb:213:in 'initialize'
/usr/local/var/rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/uri/http.rb:84:in 'initialize'
/usr/local/var/rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/uri/common.rb:214:in 'new'
/usr/local/var/rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/uri/common.rb:214:in 'parse'
/usr/local/var/rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/uri/common.rb:747:in 'parse'
/usr/local/var/rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/uri/common.rb:994:in 'URI'
/usr/local/var/rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/puffing-billy-0.2.1/lib/billy/cache.rb:73:in 'key'
/usr/local/var/rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/puffing-billy-0.2.1/lib/billy/cache.rb:21:in 'cached?'
/usr/local/var/rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/puffing-billy-0.2.1/lib/billy/proxy_connection.rb:84:in 'handle_request'
/usr/local/var/rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/puffing-billy-0.2.1/lib/billy/proxy_connection.rb:56:in 'on_message_complete'
/usr/local/var/rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/puffing-billy-0.2.1/lib/billy/proxy_connection.rb:20:in '<<'
/usr/local/var/rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/puffing-billy-0.2.1/lib/billy/proxy_connection.rb:20:in 'receive_data'
/usr/local/var/rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/eventmachine-1.0.3/lib/eventmachine.rb:187:in 'run_machine'
/usr/local/var/rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/eventmachine-1.0.3/lib/eventmachine.rb:187:in 'run'
/usr/local/var/rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/puffing-billy-0.2.1/lib/billy/proxy.rb:68:in 'main_loop'
/usr/local/var/rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/puffing-billy-0.2.1/lib/billy/proxy.rb:14:in 'block in start'
```
