### PR TITLE
Update http_parser to 0.6.0 and remove CONNECT request hack

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       em-http-request
       eventmachine
       eventmachine_httpserver
-      http_parser.rb
+      http_parser.rb (~> 0.6.0)
       multi_json
 
 GEM

--- a/lib/billy/proxy_connection.rb
+++ b/lib/billy/proxy_connection.rb
@@ -11,23 +11,10 @@ module Billy
 
     def post_init
       @parser = Http::Parser.new(self)
-      @header_data = ""
     end
 
     def receive_data(data)
-      @header_data << data if @headers.nil?
-      begin
-        @parser << data
-      rescue HTTP::Parser::Error
-        if @parser.http_method == 'CONNECT'
-          # work-around for CONNECT requests until https://github.com/tmm1/http_parser.rb/pull/15 gets merged
-          if @header_data.end_with?("\r\n\r\n")
-            restart_with_ssl(@header_data.split("\r\n").first.split(/\s+/)[1])
-          end
-        else
-          close_connection
-        end
-      end
+      @parser << data
     end
 
     def on_message_begin

--- a/puffing-billy.gemspec
+++ b/puffing-billy.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "eventmachine"
   gem.add_runtime_dependency "em-http-request"
   gem.add_runtime_dependency "eventmachine_httpserver"
-  gem.add_runtime_dependency "http_parser.rb"
+  gem.add_runtime_dependency "http_parser.rb", "~> 0.6.0"
   gem.add_runtime_dependency "multi_json"
   gem.add_runtime_dependency "capybara"
 end


### PR DESCRIPTION
Update http_parser to 0.6.0. Remove the CONNECT request hack due to bug in previous version.

NOTE: The referenced PR for http_parser in the proxy_connection comments has been merged in prior to release version 0.6.0 of http_parser so it is presumed based on the comment that this should work as expected; however, note that there are NO unit tests existing validating the behavior of proxy_connection in an https environment, as far as I could tell.
