### PR TITLE
Allow configurable Billy proxy port

### DIFF
--- a/lib/billy/config.rb
+++ b/lib/billy/config.rb
@@ -4,10 +4,11 @@ require 'tmpdir'
 module Billy
   class Config
     DEFAULT_WHITELIST = ['127.0.0.1', 'localhost']
+    RANDOM_AVAILABLE_PORT = 0 # https://github.com/eventmachine/eventmachine/wiki/FAQ#wiki-can-i-start-a-server-on-a-random-available-port
 
     attr_accessor :logger, :cache, :cache_request_headers, :whitelist, :path_blacklist, :ignore_params,
                   :persist_cache, :ignore_cache_port, :non_successful_cache_disabled, :non_successful_error_level,
-                  :non_whitelisted_requests_disabled, :cache_path
+                  :non_whitelisted_requests_disabled, :cache_path, :proxy_port
 
     def initialize
       @logger = defined?(Rails) ? Rails.logger : Logger.new(STDOUT)
@@ -26,6 +27,7 @@ module Billy
       @non_successful_error_level = :warn
       @non_whitelisted_requests_disabled = false
       @cache_path = File.join(Dir.tmpdir, 'puffing-billy')
+      @proxy_port = RANDOM_AVAILABLE_PORT
     end
   end
 

--- a/lib/billy/proxy.rb
+++ b/lib/billy/proxy.rb
@@ -73,7 +73,7 @@ module Billy
           puts e.backtrace.join("\n")
         end
 
-        @signature = EM.start_server('127.0.0.1', 0, ProxyConnection) do |p|
+        @signature = EM.start_server('127.0.0.1', Billy.config.proxy_port, ProxyConnection) do |p|
           p.handler = self
           p.cache = @cache
         end


### PR DESCRIPTION
This is needed when using puffing-billy with a service (such as SauceLabs) where the ports are restricted to a limited set.
