### PR TITLE
Allow a jsonp response's callback name to correspond to the request

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ caching. You should mostly use this for analytics and various social buttons as
 they use cache avoidance techniques, but return practically the same response
 that most often does not affect your test results.
 
+`c.dynamic_jsonp` is used for updating the name of the jsonp callback in the response based on the request.
+ This is useful if the name of your callback is based off of a timestamp or another dynamic configuration.
+
 `c.path_blacklist = []` is used to always cache specific paths on any hostnames,
 including whitelisted ones.  This is useful if your AUT has routes that get data
 from external services, such as `/api` where the ajax request is a local URL but

--- a/lib/billy/config.rb
+++ b/lib/billy/config.rb
@@ -7,7 +7,7 @@ module Billy
     RANDOM_AVAILABLE_PORT = 0 # https://github.com/eventmachine/eventmachine/wiki/FAQ#wiki-can-i-start-a-server-on-a-random-available-port
 
     attr_accessor :logger, :cache, :cache_request_headers, :whitelist, :path_blacklist, :ignore_params,
-                  :persist_cache, :ignore_cache_port, :non_successful_cache_disabled, :non_successful_error_level,
+                  :persist_cache, :dynamic_jsonp, :ignore_cache_port, :non_successful_cache_disabled, :non_successful_error_level,
                   :non_whitelisted_requests_disabled, :cache_path, :proxy_port
 
     def initialize
@@ -22,6 +22,7 @@ module Billy
       @path_blacklist = []
       @ignore_params = []
       @persist_cache = false
+      @dynamic_jsonp = false
       @ignore_cache_port = true
       @non_successful_cache_disabled = false
       @non_successful_error_level = :warn

--- a/spec/lib/billy/handlers/cache_handler_spec.rb
+++ b/spec/lib/billy/handlers/cache_handler_spec.rb
@@ -4,7 +4,7 @@ describe Billy::CacheHandler do
   let(:handler) { Billy::CacheHandler.new }
   let(:request) { {
       method:   'post',
-      url:      'http://example.test:8080/index?some=param',
+      url:      'http://example.test:8080/index?some=param&callback=dynamicCallback5678',
       headers:  {'Accept-Encoding'  => 'gzip',
                  'Cache-Control'    => 'no-cache' },
       body:     'Some body'
@@ -48,6 +48,36 @@ describe Billy::CacheHandler do
                                     request[:url],
                                     request[:headers],
                                     request[:body])).to eql({:status=>200, :headers=>{"Connection"=>"close"}, :content=>"The response body"})
+    end
+
+    context 'updating jsonp callback names enabled' do
+      before do
+        Billy.config.dynamic_jsonp = true
+      end
+
+      it 'updates the cached response if the callback is dynamic' do
+        expect(Billy::Cache.instance).to receive(:cached?).and_return(true)
+        expect(Billy::Cache.instance).to receive(:fetch).and_return({:status=>200, :headers=>{"Connection"=>"close"}, :content=> 'dynamicCallback1234({"yolo":"kitten"})'})
+        expect(handler.handle_request(request[:method],
+                                      request[:url],
+                                      request[:headers],
+                                      request[:body])).to eql({:status=>200, :headers=>{"Connection"=>"close"}, :content=>'dynamicCallback5678({"yolo":"kitten"})'})
+      end
+    end
+
+    context 'updating jsonp callback names disabled' do
+      before do
+        Billy.config.dynamic_jsonp = false
+      end
+
+      it 'does not change the response' do
+        expect(Billy::Cache.instance).to receive(:cached?).and_return(true)
+        expect(Billy::Cache.instance).to receive(:fetch).and_return({:status=>200, :headers=>{"Connection"=>"close"}, :content=> 'dynamicCallback1234({"yolo":"kitten"})'})
+        expect(handler.handle_request(request[:method],
+                                      request[:url],
+                                      request[:headers],
+                                      request[:body])).to eql({:status=>200, :headers=>{"Connection"=>"close"}, :content=>'dynamicCallback1234({"yolo":"kitten"})'})
+      end
     end
 
     it 'returns nil if the Cache fails to handle the response for some reason' do


### PR DESCRIPTION
This resolves #55.

This pull request adds a `dynamic_jsonp` config flag that changes jsonp response callback names to match the associated request param. This combined with `ignore_params` lets a developer use the caching feature for jsonp requests with dynamic callbacks (where the callback name is generated based off a key or timestamp)

I also created a barebones sample rails app that uses stripe.js for integration testing. You can see it [here](https://github.com/MarkyMarkMcDonald/Sample-Striped-Puffer).
