### PR TITLE
Adds EventMachine timeout configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,20 @@ RSpec.configure do |config|
 end
 ```
 
+## Proxy timeouts
+
+By default, the Puffing Billy proxy will use the EventMachine:HttpRequest timeouts of 5 seconds
+for connect and 10 seconds for inactivity when talking to downstream servers.
+
+These can be configured as follows:
+
+```ruby
+Billy.configure do |c|
+  c.proxied_request_connect_timeout = 20
+  c.proxied_request_inactivity_timeout = 20
+end
+```
+
 ## Customising the javascript driver
 
 If you use a customised Capybara driver, remember to set the proxy address

--- a/lib/billy/config.rb
+++ b/lib/billy/config.rb
@@ -8,7 +8,8 @@ module Billy
 
     attr_accessor :logger, :cache, :cache_request_headers, :whitelist, :path_blacklist, :ignore_params,
                   :persist_cache, :ignore_cache_port, :non_successful_cache_disabled, :non_successful_error_level,
-                  :non_whitelisted_requests_disabled, :cache_path, :proxy_port
+                  :non_whitelisted_requests_disabled, :cache_path, :proxy_port, :proxied_request_inactivity_timeout,
+                  :proxied_request_connect_timeout
 
     def initialize
       @logger = defined?(Rails) ? Rails.logger : Logger.new(STDOUT)
@@ -28,6 +29,8 @@ module Billy
       @non_whitelisted_requests_disabled = false
       @cache_path = File.join(Dir.tmpdir, 'puffing-billy')
       @proxy_port = RANDOM_AVAILABLE_PORT
+      @proxied_request_inactivity_timeout = 10 # defaults from https://github.com/igrigorik/em-http-request/wiki/Redirects-and-Timeouts
+      @proxied_request_connect_timeout = 5
     end
   end
 

--- a/lib/billy/handlers/proxy_handler.rb
+++ b/lib/billy/handlers/proxy_handler.rb
@@ -12,7 +12,10 @@ module Billy
 
     def handle_request(method, url, headers, body)
       if handles_request?(method, url, headers, body)
-        req = EventMachine::HttpRequest.new(url)
+        req = EventMachine::HttpRequest.new(url, {
+            :inactivity_timeout => Billy.config.proxied_request_inactivity_timeout,
+            :connect_timeout => Billy.config.proxied_request_connect_timeout})
+
         req = req.send(method.downcase, build_request_options(headers, body))
 
         if req.error

--- a/spec/lib/billy/handlers/proxy_handler_spec.rb
+++ b/spec/lib/billy/handlers/proxy_handler_spec.rb
@@ -151,6 +151,21 @@ describe Billy::ProxyHandler do
                                request[:headers],
                                request[:body])
       end
+
+      it 'uses the timeouts defined in configuration' do
+        allow(Billy.config).to receive(:proxied_request_inactivity_timeout).and_return(42)
+        allow(Billy.config).to receive(:proxied_request_connect_timeout).and_return(24)
+
+        expect(EventMachine::HttpRequest).to receive(:new).with(request[:url], {
+            inactivity_timeout: 42,
+            connect_timeout: 24
+        })
+
+        subject.handle_request(request[:method],
+                               request[:url],
+                               request[:headers],
+                               request[:body])
+      end
     end
   end
 end


### PR DESCRIPTION
On my current Rails project, we're faced with a particularly slow asset
compilation step. This has led to us having flakey tests, as our Puffing
Billy tests using the selenium_billy driver often timeout when compiling
assets. It'd be nice to be able to change the configuration for the
EventMachine::HttpRequest that the proxy handler uses so that we can
safely deal with slow requests.
