### PR TITLE
Don't recommend changing javascript_driver config

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ And in steps:
 ```ruby
 Before('@billy') do
   Capybara.current_driver = :poltergeist_billy
-  Capybara.javascript_driver = :poltergeist_billy
 end
 
 And /^a stub for google$/ do


### PR DESCRIPTION
`javascript_driver` is a configuration value that changes the driver used for _all_ scenarios tagged with `@javascript` after it is set. That means that it impacts tests that are run after a `@billy` test. For me, this manifested as a test suite that froze partway through and timed out. Our `@billy` tests should not impact other tests, and setting `current_driver` is sufficient to make sure this test uses billy, regardless of the presence of `@javascript`.
