### PR TITLE
Read Me Link pointing at wrong target

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ end
 
 If you use a customised Capybara driver, remember to set the proxy address
 and tell it to ignore SSL certificate warnings. See
-[lib/billy/rspec.rb](https://github.com/oesmith/puffing-billy/blob/master/lib/billy/rspec.rb)
+[lib/billy.rb](https://github.com/oesmith/puffing-billy/blob/master/lib/billy.rb)
 to see how Billy's default drivers are configured.
 
 ## FAQ


### PR DESCRIPTION
The link within Customising the javascript driver, to show how the drivers are configured, is pointing to the wrong file.  
Its currently pointing at lib/billy/rspec.rb where the function register_drivers is called.
It probably should point at lib/billy.rb where  the function register_drivers is defined, and includes the actual configuration needed for puffing billy with Capybara drivers.
