### PR TITLE
Rubocop code cleanup

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,18 +1,18 @@
 # A sample Guardfile
 # More info at https://github.com/guard/guard#readme
 
-guard 'rspec', :version => 2 do
+guard 'rspec', version: 2 do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
-  watch('spec/spec_helper.rb')  { "spec" }
+  watch('spec/spec_helper.rb')  { 'spec' }
 
   # Rails example
   watch(%r{^app/(.+)\.rb$})                           { |m| "spec/#{m[1]}_spec.rb" }
   watch(%r{^app/(.*)(\.erb|\.haml)$})                 { |m| "spec/#{m[1]}#{m[2]}_spec.rb" }
   watch(%r{^app/controllers/(.+)_(controller)\.rb$})  { |m| ["spec/routing/#{m[1]}_routing_spec.rb", "spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb", "spec/acceptance/#{m[1]}_spec.rb"] }
-  watch(%r{^spec/support/(.+)\.rb$})                  { "spec" }
-  watch('config/routes.rb')                           { "spec/routing" }
-  watch('app/controllers/application_controller.rb')  { "spec/controllers" }
+  watch(%r{^spec/support/(.+)\.rb$})                  { 'spec' }
+  watch('config/routes.rb')                           { 'spec/routing' }
+  watch('app/controllers/application_controller.rb')  { 'spec/controllers' }
 
   # Capybara request specs
   watch(%r{^app/views/(.+)/.*\.(erb|haml)$})          { |m| "spec/requests/#{m[1]}_spec.rb" }

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,2 @@
 #!/usr/bin/env rake
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'

--- a/lib/billy.rb
+++ b/lib/billy.rb
@@ -1,15 +1,15 @@
-require "billy/version"
-require "billy/config"
-require "billy/handlers/handler"
-require "billy/handlers/request_handler"
-require "billy/handlers/stub_handler"
-require "billy/handlers/proxy_handler"
-require "billy/handlers/cache_handler"
-require "billy/proxy_request_stub"
-require "billy/cache"
-require "billy/proxy"
-require "billy/proxy_connection"
-require "billy/railtie" if defined?(Rails)
+require 'billy/version'
+require 'billy/config'
+require 'billy/handlers/handler'
+require 'billy/handlers/request_handler'
+require 'billy/handlers/stub_handler'
+require 'billy/handlers/proxy_handler'
+require 'billy/handlers/cache_handler'
+require 'billy/proxy_request_stub'
+require 'billy/cache'
+require 'billy/proxy'
+require 'billy/proxy_connection'
+require 'billy/railtie' if defined?(Rails)
 
 module Billy
   def self.proxy
@@ -44,8 +44,8 @@ module Billy
       Capybara.register_driver :webkit_billy do |app|
         driver = Capybara::Webkit::Driver.new(app)
         driver.browser.ignore_ssl_errors
-        driver.browser.set_proxy(:host => Billy.proxy.host,
-                                 :port => Billy.proxy.port)
+        driver.browser.set_proxy(host: Billy.proxy.host,
+                                 port: Billy.proxy.port)
         driver
       end
     end
@@ -55,9 +55,9 @@ module Billy
         profile = Selenium::WebDriver::Firefox::Profile.new
         profile.assume_untrusted_certificate_issuer = false
         profile.proxy = Selenium::WebDriver::Proxy.new(
-          :http => "#{Billy.proxy.host}:#{Billy.proxy.port}",
-          :ssl => "#{Billy.proxy.host}:#{Billy.proxy.port}")
-        Capybara::Selenium::Driver.new(app, :profile => profile)
+          http: "#{Billy.proxy.host}:#{Billy.proxy.port}",
+          ssl: "#{Billy.proxy.host}:#{Billy.proxy.port}")
+        Capybara::Selenium::Driver.new(app, profile: profile)
       end
     end
   end

--- a/lib/billy/cache.rb
+++ b/lib/billy/cache.rb
@@ -60,6 +60,7 @@ module Billy
             f.write(cached.to_yaml(Encoding: :Utf8))
           end
         rescue StandardError => e
+          Billy.log :error, "Error storing cache file: #{e.message}"
         end
       end
     end
@@ -76,7 +77,7 @@ module Billy
               method + '_' + Digest::SHA1.hexdigest(scope.to_s + merge_cached_response_key)
             else
               method + '_' + url.host + '_' + Digest::SHA1.hexdigest(scope.to_s + url.to_s)
-        end
+            end
       body_msg = ''
 
       if method == 'post' && !ignore_params && !merge_cached_response_key

--- a/lib/billy/cache.rb
+++ b/lib/billy/cache.rb
@@ -17,49 +17,47 @@ module Billy
     def cached?(method, url, body)
       # Only log the key the first time it's looked up (in this method)
       key = key(method, url, body, true)
-      !@cache[key].nil? or persisted?(key)
+      !@cache[key].nil? || persisted?(key)
     end
 
     def persisted?(key)
-      Billy.config.persist_cache and File.exists?(cache_file(key))
+      Billy.config.persist_cache && File.exist?(cache_file(key))
     end
 
     def fetch(method, url, body)
       key = key(method, url, body)
-      @cache[key] or fetch_from_persistence(key)
+      @cache[key] || fetch_from_persistence(key)
     end
 
     def fetch_from_persistence(key)
-      begin
-        @cache[key] = YAML.load(File.open(cache_file(key))) if persisted?(key)
-      rescue ArgumentError => e
-        Billy.log :error, "Could not parse YAML: #{e.message}"
-        nil
-      end
+      @cache[key] = YAML.load(File.open(cache_file(key))) if persisted?(key)
+    rescue ArgumentError => e
+      Billy.log :error, "Could not parse YAML: #{e.message}"
+      nil
     end
 
     def store(method, url, request_headers, body, response_headers, status, content)
       cached = {
-        :scope => scope,
-        :url => format_url(url),
-        :body => body,
-        :status => status,
-        :method => method,
-        :headers => response_headers,
-        :content => content
+        scope: scope,
+        url: format_url(url),
+        body: body,
+        status: status,
+        method: method,
+        headers: response_headers,
+        content: content
       }
 
-      cached.merge!({:request_headers => request_headers}) if Billy.config.cache_request_headers
+      cached.merge!(request_headers: request_headers) if Billy.config.cache_request_headers
 
       key = key(method, url, body)
       @cache[key] = cached
 
       if Billy.config.persist_cache
-        Dir.mkdir(Billy.config.cache_path) unless File.exists?(Billy.config.cache_path)
+        Dir.mkdir(Billy.config.cache_path) unless File.exist?(Billy.config.cache_path)
 
         begin
           File.open(cache_file(key), 'w') do |f|
-            f.write(cached.to_yaml(:Encoding => :Utf8))
+            f.write(cached.to_yaml(Encoding: :Utf8))
           end
         rescue StandardError => e
         end
@@ -75,33 +73,33 @@ module Billy
       merge_cached_response_key = _merge_cached_response_key(orig_url)
       url = Addressable::URI.parse(format_url(orig_url, ignore_params))
       key = if merge_cached_response_key
-          method+'_'+Digest::SHA1.hexdigest(scope.to_s + merge_cached_response_key)
-        else
-          method+'_'+url.host+'_'+Digest::SHA1.hexdigest(scope.to_s + url.to_s)
+              method + '_' + Digest::SHA1.hexdigest(scope.to_s + merge_cached_response_key)
+            else
+              method + '_' + url.host + '_' + Digest::SHA1.hexdigest(scope.to_s + url.to_s)
         end
       body_msg = ''
 
       if method == 'post' && !ignore_params && !merge_cached_response_key
-        body_formatted = JSONUtils::json?(body.to_s) ? JSONUtils::sort_json(body.to_s) : body.to_s
+        body_formatted = JSONUtils.json?(body.to_s) ? JSONUtils.sort_json(body.to_s) : body.to_s
         body_msg = " with body '#{body_formatted}'"
-        key += '_'+Digest::SHA1.hexdigest(body_formatted)
+        key += '_' + Digest::SHA1.hexdigest(body_formatted)
       end
 
       Billy.log(:info, "puffing-billy: CACHE KEY for '#{orig_url}#{body_msg}' is '#{key}'") if log_key
       key
     end
 
-    def format_url(url, ignore_params=false, dynamic_jsonp=Billy.config.dynamic_jsonp)
+    def format_url(url, ignore_params = false, dynamic_jsonp = Billy.config.dynamic_jsonp)
       url = Addressable::URI.parse(url)
       port_to_include = Billy.config.ignore_cache_port ? '' : ":#{url.port}"
-      formatted_url = url.scheme+'://'+url.host+port_to_include+url.path
+      formatted_url = url.scheme + '://' + url.host + port_to_include + url.path
 
       return formatted_url if ignore_params
 
       if url.query
         query_string = if dynamic_jsonp
                          query_hash = Rack::Utils.parse_query(url.query)
-                         Billy.config.dynamic_jsonp_keys.each{|k| query_hash.delete(k) }
+                         Billy.config.dynamic_jsonp_keys.each { |k| query_hash.delete(k) }
                          Rack::Utils.build_query(query_hash)
                        else
                          url.query
@@ -110,7 +108,7 @@ module Billy
         formatted_url += "?#{query_string}"
       end
 
-      formatted_url += '#'+url.fragment if url.fragment
+      formatted_url += '#' + url.fragment if url.fragment
 
       formatted_url
     end
@@ -124,10 +122,10 @@ module Billy
     end
 
     def with_scope(use_scope = nil, &block)
-      raise ArgumentError, 'Expected a block but none was received.' if block.nil?
+      fail ArgumentError, 'Expected a block but none was received.' if block.nil?
       original_scope = scope
       scope_to use_scope
-      block.call()
+      block.call
     ensure
       scope_to original_scope
     end

--- a/lib/billy/config.rb
+++ b/lib/billy/config.rb
@@ -25,7 +25,7 @@ module Billy
       @ignore_params = []
       @persist_cache = false
       @dynamic_jsonp = false
-      @dynamic_jsonp_keys = ["callback"]
+      @dynamic_jsonp_keys = ['callback']
       @ignore_cache_port = true
       @non_successful_cache_disabled = false
       @non_successful_error_level = :warn

--- a/lib/billy/handlers/cache_handler.rb
+++ b/lib/billy/handlers/cache_handler.rb
@@ -46,6 +46,5 @@ module Billy
         end
       end
     end
-
   end
 end

--- a/lib/billy/handlers/cache_handler.rb
+++ b/lib/billy/handlers/cache_handler.rb
@@ -7,6 +7,8 @@ module Billy
     extend Forwardable
     include Handler
 
+    attr_reader :cache
+
     def_delegators :cache, :reset, :cached?
 
     def initialize
@@ -29,7 +31,7 @@ module Billy
       nil
     end
 
-    def handles_request?(method, url, headers, body)
+    def handles_request?(method, url, _headers, body)
       cached?(method, url, body)
     end
 
@@ -38,15 +40,12 @@ module Billy
     def replace_response_callback(response, url)
       request_uri = Addressable::URI.parse(url)
       if request_uri.query
-        params = CGI::parse(request_uri.query)
-        if params['callback'].any? and response[:content].match(/\w+\(/)
+        params = CGI.parse(request_uri.query)
+        if params['callback'].any? && response[:content].match(/\w+\(/)
           response[:content].sub!(/\w+\(/, params['callback'].first + '(')
         end
       end
     end
 
-    def cache
-      @cache
-    end
   end
 end

--- a/lib/billy/handlers/handler.rb
+++ b/lib/billy/handlers/handler.rb
@@ -15,7 +15,7 @@ module Billy
     # @return [Hash]                A hash with the keys [:status, :headers, :content]
     #                               Returns {:error => "Some error message"} if a failure occurs.
     #                               Returns nil if the request cannot be fulfilled.
-    def handle_request(http_method, url, headers, body)
+    def handle_request(_http_method, _url, _headers, _body)
       { error: 'The handler has not overridden the handle_request method!' }
     end
 
@@ -29,7 +29,7 @@ module Billy
     # @param  [String] body         The body of the HTTP request.
     # @return [Boolean]             True if the Handler can respond to the request, else false.
     #
-    def handles_request?(http_method, url, headers, body)
+    def handles_request?(_http_method, _url, _headers, _body)
       false
     end
 

--- a/lib/billy/handlers/proxy_handler.rb
+++ b/lib/billy/handlers/proxy_handler.rb
@@ -7,20 +7,20 @@ module Billy
   class ProxyHandler
     include Handler
 
-    def handles_request?(method, url, headers, body)
+    def handles_request?(_method, url, _headers, _body)
       !disabled_request?(url)
     end
 
     def handle_request(method, url, headers, body)
       if handles_request?(method, url, headers, body)
-        req = EventMachine::HttpRequest.new(url, {
-            :inactivity_timeout => Billy.config.proxied_request_inactivity_timeout,
-            :connect_timeout => Billy.config.proxied_request_connect_timeout})
+        req = EventMachine::HttpRequest.new(url,
+                                            inactivity_timeout: Billy.config.proxied_request_inactivity_timeout,
+                                            connect_timeout: Billy.config.proxied_request_connect_timeout)
 
         req = req.send(method.downcase, build_request_options(headers, body))
 
         if req.error
-          return { :error => "Request to #{url} failed with error: #{req.error}" }
+          return { error: "Request to #{url} failed with error: #{req.error}" }
         end
 
         if req.response
@@ -28,7 +28,7 @@ module Billy
 
           unless allowed_response_code?(response[:status])
             if Billy.config.non_successful_error_level == :error
-              return { :error => "Request failed due to response status #{response[:status]} for '#{url}' which was not allowed." }
+              return { error: "Request failed due to response status #{response[:status]} for '#{url}' which was not allowed." }
             else
               Billy.log(:warn, "puffing-billy: Received response status code #{response[:status]} for '#{url}'")
             end
@@ -48,14 +48,14 @@ module Billy
     private
 
     def build_request_options(headers, body)
-      headers = Hash[headers.map { |k,v| [k.downcase, v] }]
+      headers = Hash[headers.map { |k, v| [k.downcase, v] }]
       headers.delete('accept-encoding')
 
       req_opts = {
-          :redirects => 0,
-          :keepalive => false,
-          :head => headers,
-          :ssl => { :verify => false }
+        redirects: 0,
+        keepalive: false,
+        head: headers,
+        ssl: { verify: false }
       }
       req_opts[:body] = body if body
       req_opts
@@ -63,9 +63,9 @@ module Billy
 
     def process_response(req)
       response = {
-          :status  => req.response_header.status,
-          :headers => req.response_header.raw,
-          :content => req.response.force_encoding('BINARY') }
+        status: req.response_header.status,
+        headers: req.response_header.raw,
+        content: req.response.force_encoding('BINARY') }
       response[:headers].merge!('Connection' => 'close')
       response[:headers].delete('Transfer-Encoding')
       response
@@ -84,7 +84,7 @@ module Billy
       successful_status?(status)
     end
 
-    def cacheable?(url, headers, status)
+    def cacheable?(url, _headers, status)
       return false unless Billy.config.cache
 
       url = Addressable::URI.parse(url)
@@ -99,7 +99,7 @@ module Billy
     end
 
     def blacklisted_path?(path)
-      !Billy.config.path_blacklist.index{|bl| path.include?(bl)}.nil?
+      !Billy.config.path_blacklist.index { |bl| path.include?(bl) }.nil?
     end
 
     def successful_status?(status)

--- a/lib/billy/handlers/request_handler.rb
+++ b/lib/billy/handlers/request_handler.rb
@@ -6,9 +6,9 @@ module Billy
     def_delegators :stub_handler, :stub
 
     def handlers
-      @handlers ||= { :stubs => StubHandler.new,
-                      :cache => CacheHandler.new,
-                      :proxy => ProxyHandler.new }
+      @handlers ||= { stubs: StubHandler.new,
+                      cache: CacheHandler.new,
+                      proxy: ProxyHandler.new }
     end
 
     def handle_request(method, url, headers, body)
@@ -20,7 +20,7 @@ module Billy
       end
 
       body_msg = method == 'post' ? " with body '#{body}'" : ''
-      { :error => "Connection to #{url}#{body_msg} not cached and new http connections are disabled" }
+      { error: "Connection to #{url}#{body_msg} not cached and new http connections are disabled" }
     end
 
     def handles_request?(method, url, headers, body)
@@ -32,9 +32,7 @@ module Billy
     end
 
     def reset
-      handlers.each_value do |handler|
-        handler.reset
-      end
+      handlers.each_value(&:reset)
     end
 
     def reset_stubs
@@ -46,7 +44,7 @@ module Billy
     end
 
     def restore_cache
-      warn "[DEPRECATION] `restore_cache` is deprecated as cache files are dynamically checked. Use `reset_cache` if you just want to clear the cache."
+      warn '[DEPRECATION] `restore_cache` is deprecated as cache files are dynamically checked. Use `reset_cache` if you just want to clear the cache.'
       reset_cache
     end
 

--- a/lib/billy/handlers/stub_handler.rb
+++ b/lib/billy/handlers/stub_handler.rb
@@ -8,7 +8,7 @@ module Billy
     def handle_request(method, url, headers, body)
       if handles_request?(method, url, headers, body)
         if (stub = find_stub(method, url))
-          query_string = Addressable::URI.parse(url).query || ""
+          query_string = Addressable::URI.parse(url).query || ''
           params = CGI.parse(query_string)
           stub.call(params, headers, body).tap do |response|
             Billy.log(:info, "puffing-billy: STUB #{method} for '#{url}'")
@@ -20,7 +20,7 @@ module Billy
       nil
     end
 
-    def handles_request?(method, url, headers, body)
+    def handles_request?(method, url, _headers, _body)
       !find_stub(method, url).nil?
     end
 

--- a/lib/billy/json_utils.rb
+++ b/lib/billy/json_utils.rb
@@ -2,7 +2,6 @@ require 'json'
 
 module Billy
   module JSONUtils
-
     def self.json?(value)
       !!JSON.parse(value)
     rescue JSON::ParserError, TypeError
@@ -33,7 +32,7 @@ module Billy
     #   Processing JSON in this way enables a consistent SHA to be derived from
     #   JSON payloads which have the same name/value pairs, but different orders.
     def self.sort_json(json_str)
-      JSONUtils::sort_hash_keys(JSON.parse(json_str, symbolize_names: true)).to_json
+      JSONUtils.sort_hash_keys(JSON.parse(json_str, symbolize_names: true)).to_json
     end
   end
 end

--- a/lib/billy/proxy_connection.rb
+++ b/lib/billy/proxy_connection.rb
@@ -37,7 +37,7 @@ module Billy
       else
         if @ssl
           uri = Addressable::URI.parse(@parser.request_url)
-          @url = "https://#{@ssl}#{[uri.path,uri.query].compact.join('?')}"
+          @url = "https://#{@ssl}#{[uri.path, uri.query].compact.join('?')}"
         else
           @url = @parser.request_url
         end
@@ -52,17 +52,17 @@ module Billy
       @parser = Http::Parser.new(self)
       send_data("HTTP/1.0 200 Connection established\r\nProxy-agent: Puffing-Billy/0.0.0\r\n\r\n")
       start_tls(
-        :private_key_file => File.expand_path('../mitm.key', __FILE__),
-        :cert_chain_file => File.expand_path('../mitm.crt', __FILE__)
+        private_key_file: File.expand_path('../mitm.key', __FILE__),
+        cert_chain_file: File.expand_path('../mitm.crt', __FILE__)
       )
     end
 
     def handle_request
       EM.synchrony do
         handler.handle_request(@parser.http_method, @url, @headers, @body).tap do |response|
-          if response.has_key?(:error)
+          if response.key?(:error)
             close_connection
-            raise "puffing-billy: #{response[:error]}"
+            fail "puffing-billy: #{response[:error]}"
           else
             send_response(response)
           end

--- a/lib/billy/proxy_request_stub.rb
+++ b/lib/billy/proxy_request_stub.rb
@@ -3,10 +3,10 @@ require 'multi_json'
 module Billy
   class ProxyRequestStub
     def initialize(url, options = {})
-      @options = {:method => :get}.merge(options)
+      @options = { method: :get }.merge(options)
       @method = @options[:method].to_s.upcase
       @url = url
-      @response = {code: 204, headers: {}, text: ""}
+      @response = { code: 204, headers: {}, text: '' }
     end
 
     def and_return(response)
@@ -27,10 +27,10 @@ module Billy
       headers['Content-Type'] = res[:content_type] if res[:content_type]
 
       if res[:json]
-        headers = {'Content-Type' => 'application/json'}.merge(headers)
+        headers = { 'Content-Type' => 'application/json' }.merge(headers)
         body = MultiJson.dump(res[:json])
       elsif res[:jsonp]
-        headers = {'Content-Type' => 'application/javascript'}.merge(headers)
+        headers = { 'Content-Type' => 'application/javascript' }.merge(headers)
         if res[:callback]
           callback = res[:callback]
         elsif res[:callback_param]
@@ -40,11 +40,11 @@ module Billy
         end
         body = "#{callback}(#{MultiJson.dump(res[:jsonp])})"
       elsif res[:text]
-        headers = {'Content-Type' => 'text/plain'}.merge(headers)
+        headers = { 'Content-Type' => 'text/plain' }.merge(headers)
         body = res[:text]
       elsif res[:redirect_to]
         code = 302
-        headers = {'Location' => res[:redirect_to]}
+        headers = { 'Location' => res[:redirect_to] }
       else
         body = res[:body]
       end

--- a/lib/billy/version.rb
+++ b/lib/billy/version.rb
@@ -1,3 +1,3 @@
 module Billy
-  VERSION = "0.4.1"
+  VERSION = '0.4.1'
 end

--- a/lib/tasks/billy.rake
+++ b/lib/tasks/billy.rake
@@ -1,7 +1,6 @@
 require 'addressable/uri'
 
 namespace :cache do
-
   desc 'Print out all cache file information'
   task :print_all do
     cache_array = load_cache
@@ -12,9 +11,9 @@ namespace :cache do
   end
 
   desc 'Print out specific cache file information'
-  task :print_details, :sha do |t, args|
-    raise "Missing sha; usage: rake cache:print_details['<sha>']" unless args[:sha]
-    cache_array = load_cache(Billy.config.cache_path, '*'+args[:sha]+'*.yml')
+  task :print_details, :sha do |_t, args|
+    fail "Missing sha; usage: rake cache:print_details['<sha>']" unless args[:sha]
+    cache_array = load_cache(Billy.config.cache_path, '*' + args[:sha] + '*.yml')
 
     sort_cache(cache_array).each do |cache|
       print_cache_details(cache)
@@ -22,10 +21,10 @@ namespace :cache do
   end
 
   desc 'Find specific cache files by URL'
-  task :find_by_url, :api_path do |t, args|
-    raise "Missing api path; usage: rake cache:find_by_url['<api_path>']" unless args[:api_path]
+  task :find_by_url, :api_path do |_t, args|
+    fail "Missing api path; usage: rake cache:find_by_url['<api_path>']" unless args[:api_path]
     cache_array = load_cache
-    filtered_cache_array = cache_array.select {|f| f[:url_path].include?(args[:api_path]) }
+    filtered_cache_array = cache_array.select { |f| f[:url_path].include?(args[:api_path]) }
 
     sort_cache(filtered_cache_array).each do |cache|
       print_cache_details(cache)
@@ -33,10 +32,10 @@ namespace :cache do
   end
 
   desc 'Find specific cache files by scope'
-  task :find_by_scope, :scope do |t, args|
-    raise "Missing scope; usage: rake cache:find_by_scope['<scope>']" unless args[:scope]
+  task :find_by_scope, :scope do |_t, args|
+    fail "Missing scope; usage: rake cache:find_by_scope['<scope>']" unless args[:scope]
     cache_array = load_cache
-    filtered_cache_array = cache_array.select {|f| f[:scope] && f[:scope].include?(args[:scope]) }
+    filtered_cache_array = cache_array.select { |f| f[:scope] && f[:scope].include?(args[:scope]) }
 
     sort_cache(filtered_cache_array).each do |cache|
       print_cache_details(cache)
@@ -46,7 +45,7 @@ namespace :cache do
   desc 'Find cache files with non-successful status codes'
   task :find_non_successful do
     cache_array = load_cache
-    filtered_cache_array = cache_array.select {|f| !(200..299).include?(f[:status]) }
+    filtered_cache_array = cache_array.select { |f| !(200..299).include?(f[:status]) }
 
     sort_cache(filtered_cache_array).each do |cache|
       print_cache_details(cache)
@@ -57,11 +56,11 @@ namespace :cache do
     cache_path  = Rails.root.join(cache_directory)
     cache_array = []
 
-    Dir.glob(cache_path+file_pattern) do |filename|
+    Dir.glob(cache_path + file_pattern) do |filename|
       data = load_cache_file(filename)
       url = Addressable::URI.parse(data[:url])
-      data[:url_path] = "#{url.path}#{url.query ? '?'+url.query : ''}#{url.fragment ? '#'+url.fragment : ''}"
-      data[:filename] = filename.gsub(Rails.root.to_s+'/','')
+      data[:url_path] = "#{url.path}#{url.query ? '?' + url.query : ''}#{url.fragment ? '#' + url.fragment : ''}"
+      data[:filename] = filename.gsub(Rails.root.to_s + '/', '')
       cache_array << data
     end
     cache_array
@@ -85,5 +84,4 @@ namespace :cache do
   def sort_cache(cache, key = :url_path)
     cache.sort_by { |hsh| hsh[key] }
   end
-
 end

--- a/puffing-billy.gemspec
+++ b/puffing-billy.gemspec
@@ -2,36 +2,36 @@
 require File.expand_path('../lib/billy/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Olly Smith"]
-  gem.email         = ["olly.smith@gmail.com"]
-  gem.description   = %q{A stubbing proxy server for ruby. Connect it to your browser in integration tests to fake interactions with remote HTTP(S) servers.}
-  gem.summary       = %q{Easy request stubs for browser tests.}
-  gem.homepage      = "https://github.com/oesmith/puffing-billy"
+  gem.authors       = ['Olly Smith']
+  gem.email         = ['olly.smith@gmail.com']
+  gem.description   = 'A stubbing proxy server for ruby. Connect it to your browser in integration tests to fake interactions with remote HTTP(S) servers.'
+  gem.summary       = 'Easy request stubs for browser tests.'
+  gem.homepage      = 'https://github.com/oesmith/puffing-billy'
 
-  gem.files         = `git ls-files`.split($\)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  gem.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
+  gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.name          = "puffing-billy"
-  gem.require_paths = ["lib"]
+  gem.name          = 'puffing-billy'
+  gem.require_paths = ['lib']
   gem.version       = Billy::VERSION
 
-  gem.add_development_dependency "rspec"
-  gem.add_development_dependency "thin"
-  gem.add_development_dependency "faraday"
-  gem.add_development_dependency "poltergeist"
-  gem.add_development_dependency "selenium-webdriver"
-  gem.add_development_dependency "capybara"
-  gem.add_development_dependency "capybara-webkit", "~> 1.0"
-  gem.add_development_dependency "rack"
-  gem.add_development_dependency "guard"
-  gem.add_development_dependency "rb-inotify"
-  gem.add_development_dependency "pry"
-  gem.add_development_dependency "cucumber"
-  gem.add_runtime_dependency "addressable"
-  gem.add_runtime_dependency "eventmachine"
-  gem.add_runtime_dependency "em-synchrony"
-  gem.add_runtime_dependency "em-http-request"
-  gem.add_runtime_dependency "eventmachine_httpserver"
-  gem.add_runtime_dependency "http_parser.rb", "~> 0.6.0"
-  gem.add_runtime_dependency "multi_json"
+  gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'thin'
+  gem.add_development_dependency 'faraday'
+  gem.add_development_dependency 'poltergeist'
+  gem.add_development_dependency 'selenium-webdriver'
+  gem.add_development_dependency 'capybara'
+  gem.add_development_dependency 'capybara-webkit', '~> 1.0'
+  gem.add_development_dependency 'rack'
+  gem.add_development_dependency 'guard'
+  gem.add_development_dependency 'rb-inotify'
+  gem.add_development_dependency 'pry'
+  gem.add_development_dependency 'cucumber'
+  gem.add_runtime_dependency 'addressable'
+  gem.add_runtime_dependency 'eventmachine'
+  gem.add_runtime_dependency 'em-synchrony'
+  gem.add_runtime_dependency 'em-http-request'
+  gem.add_runtime_dependency 'eventmachine_httpserver'
+  gem.add_runtime_dependency 'http_parser.rb', '~> 0.6.0'
+  gem.add_runtime_dependency 'multi_json'
 end

--- a/spec/features/examples/facebook_api_spec.rb
+++ b/spec/features/examples/facebook_api_spec.rb
@@ -1,22 +1,22 @@
 require 'spec_helper'
 require 'base64'
 
-describe 'Facebook API example', :type => :feature, :js => true do
+describe 'Facebook API example', type: :feature, js: true do
   before do
-    proxy.stub('https://www.facebook.com:443/dialog/oauth').and_return(Proc.new { |params,_,_|
+    proxy.stub('https://www.facebook.com:443/dialog/oauth').and_return(proc do |params, _, _|
       # mock a signed request from facebook.  the JS api never verifies the
       # signature, so all it needs is the base64-encoded payload
       signed_request = "xxxxxxxxxx.#{Base64.encode64('{"user_id":"1234567"}')}"
       # redirect to the 'redirect_uri', with some extra crap in the query string
-      {:redirect_to => "#{params['redirect_uri'][0]}&access_token=foobar&expires_in=600&base_domain=localhost&https=1&signed_request=#{signed_request}"}
-    })
+      { redirect_to: "#{params['redirect_uri'][0]}&access_token=foobar&expires_in=600&base_domain=localhost&https=1&signed_request=#{signed_request}" }
+    end)
 
-    proxy.stub('https://graph.facebook.com:443/me').and_return(:jsonp => {:name => 'Tester 1'})
+    proxy.stub('https://graph.facebook.com:443/me').and_return(jsonp: { name: 'Tester 1' })
   end
 
   it 'should show me as logged-in' do
     visit '/facebook_api.html'
-    click_on "Login"
-    expect(page).to have_content "Hi, Tester 1"
+    click_on 'Login'
+    expect(page).to have_content 'Hi, Tester 1'
   end
 end

--- a/spec/features/examples/tumblr_api_spec.rb
+++ b/spec/features/examples/tumblr_api_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-describe 'Tumblr API example', :type => :feature, :js => true do
+describe 'Tumblr API example', type: :feature, js: true do
   before do
     proxy.stub('http://blog.howmanyleft.co.uk/api/read/json').and_return(
-      :jsonp => {
-        :posts => [
+      jsonp: {
+        posts: [
           {
             'regular-title' => 'News Item 1',
             'url-with-slug' => 'http://example.com/news/1',
@@ -16,14 +16,14 @@ describe 'Tumblr API example', :type => :feature, :js => true do
             'regular-body' => 'News item 2 content here'
           }
         ]
-    })
+      })
   end
 
   it 'should show news stories' do
     visit '/tumblr_api.html'
-    expect(page).to have_link('News Item 1', :href => 'http://example.com/news/1')
+    expect(page).to have_link('News Item 1', href: 'http://example.com/news/1')
     expect(page).to have_content('News item 1 content here')
-    expect(page).to have_link('News Item 2', :href => 'http://example.com/news/2')
+    expect(page).to have_link('News Item 2', href: 'http://example.com/news/2')
     expect(page).to have_content('News item 2 content here')
   end
 end

--- a/spec/lib/billy/cache_spec.rb
+++ b/spec/lib/billy/cache_spec.rb
@@ -27,13 +27,13 @@ describe Billy::Cache do
         expect { cache.format_url(pipe_url) }.not_to raise_error
       end
 
-      context "when dynamic_jsonp is true" do
+      context 'when dynamic_jsonp is true' do
         it 'omits the callback param by default' do
           expect(cache.format_url(params_url_with_callback, false, true)).to eq params_url
         end
 
         it 'omits the params listed in Billy.config.dynamic_jsonp_keys' do
-          allow(Billy.config).to receive(:dynamic_jsonp_keys) { ["foo"] }
+          allow(Billy.config).to receive(:dynamic_jsonp_keys) { ['foo'] }
 
           expect(cache.format_url(params_url_with_callback, false, true)).to eq "#{base_url}?callback=quux"
         end
@@ -56,11 +56,10 @@ describe Billy::Cache do
       end
     end
 
-    context "with merge_cached_responses_whitelist set" do
-
-      let(:analytics_url1) { "http://www.example-analytics.com/user/SDF879932/" }
-      let(:analytics_url2) { "http://www.example-analytics.com/user/OIWEMLW39/" }
-      let(:regular_url) { "http://www.example-analytics.com/user.js" }
+    context 'with merge_cached_responses_whitelist set' do
+      let(:analytics_url1) { 'http://www.example-analytics.com/user/SDF879932/' }
+      let(:analytics_url2) { 'http://www.example-analytics.com/user/OIWEMLW39/' }
+      let(:regular_url) { 'http://www.example-analytics.com/user.js' }
 
       let(:regex_to_match_analytics_urls_only) do
         # Note that it matches the forward slash at the end of the URL, which doesn't match regular_url:
@@ -74,19 +73,18 @@ describe Billy::Cache do
       end
 
       it "has one cache key for the two analytics urls that match, and a separate one for the other that doesn't" do
-        expect(cache.key("post", analytics_url1, "body")).to eq cache.key("post", analytics_url2, "body")
-        expect(cache.key("post", analytics_url1, "body")).not_to eq cache.key("post", regular_url, "body")
+        expect(cache.key('post', analytics_url1, 'body')).to eq cache.key('post', analytics_url2, 'body')
+        expect(cache.key('post', analytics_url1, 'body')).not_to eq cache.key('post', regular_url, 'body')
       end
 
-      it "More specifically, the cache keys should be identical for the 2 analytics urls" do
-        identical_cache_key = "post_5fcb7a450e4cd54dcffcb526212757ee0ca9dc17"
-        distinct_cache_key = "post_www.example-analytics.com_81f097654a523bd7ddb10fd4aee781723e076a1a_02083f4579e08a612425c0c1a17ee47add783b94"
+      it 'More specifically, the cache keys should be identical for the 2 analytics urls' do
+        identical_cache_key = 'post_5fcb7a450e4cd54dcffcb526212757ee0ca9dc17'
+        distinct_cache_key = 'post_www.example-analytics.com_81f097654a523bd7ddb10fd4aee781723e076a1a_02083f4579e08a612425c0c1a17ee47add783b94'
 
-        expect(cache.key("post", analytics_url1, "body")).to eq identical_cache_key
-        expect(cache.key("post", regular_url, "body")).to eq distinct_cache_key
-        expect(cache.key("post", analytics_url2, "body")).to eq identical_cache_key
+        expect(cache.key('post', analytics_url1, 'body')).to eq identical_cache_key
+        expect(cache.key('post', regular_url, 'body')).to eq distinct_cache_key
+        expect(cache.key('post', analytics_url2, 'body')).to eq identical_cache_key
       end
-
     end
   end
 end

--- a/spec/lib/billy/handlers/cache_handler_spec.rb
+++ b/spec/lib/billy/handlers/cache_handler_spec.rb
@@ -2,13 +2,15 @@ require 'spec_helper'
 
 describe Billy::CacheHandler do
   let(:handler) { Billy::CacheHandler.new }
-  let(:request) { {
+  let(:request) do
+    {
       method:   'post',
       url:      'http://example.test:8080/index?some=param&callback=dynamicCallback5678',
-      headers:  {'Accept-Encoding'  => 'gzip',
-                 'Cache-Control'    => 'no-cache' },
+      headers:  { 'Accept-Encoding'  => 'gzip',
+                  'Cache-Control'    => 'no-cache' },
       body:     'Some body'
-  } }
+    }
+  end
 
   it 'delegates #reset to the cache' do
     expect(Billy::Cache.instance).to receive(:reset).at_least(:once)
@@ -23,12 +25,12 @@ describe Billy::CacheHandler do
   describe '#handles_request?' do
     it 'handles the request if it is cached' do
       expect(Billy::Cache.instance).to receive(:cached?).and_return(true)
-      expect(handler.handles_request?(nil,nil,nil,nil)).to be true
+      expect(handler.handles_request?(nil, nil, nil, nil)).to be true
     end
 
     it 'does not handle the request if it is not cached' do
       expect(Billy::Cache.instance).to receive(:cached?).and_return(false)
-      expect(handler.handles_request?(nil,nil,nil,nil)).to be false
+      expect(handler.handles_request?(nil, nil, nil, nil)).to be false
     end
   end
 
@@ -43,11 +45,11 @@ describe Billy::CacheHandler do
 
     it 'returns a cached response if the request can be handled' do
       expect(Billy::Cache.instance).to receive(:cached?).and_return(true)
-      expect(Billy::Cache.instance).to receive(:fetch).and_return({:status=>200, :headers=>{"Connection"=>"close"}, :content=>"The response body"})
+      expect(Billy::Cache.instance).to receive(:fetch).and_return(status: 200, headers: { 'Connection' => 'close' }, content: 'The response body')
       expect(handler.handle_request(request[:method],
                                     request[:url],
                                     request[:headers],
-                                    request[:body])).to eql({:status=>200, :headers=>{"Connection"=>"close"}, :content=>"The response body"})
+                                    request[:body])).to eql(status: 200, headers: { 'Connection' => 'close' }, content: 'The response body')
     end
 
     context 'updating jsonp callback names enabled' do
@@ -57,20 +59,20 @@ describe Billy::CacheHandler do
 
       it 'updates the cached response if the callback is dynamic' do
         expect(Billy::Cache.instance).to receive(:cached?).and_return(true)
-        expect(Billy::Cache.instance).to receive(:fetch).and_return({:status=>200, :headers=>{"Connection"=>"close"}, :content=> 'dynamicCallback1234({"yolo":"kitten"})'})
+        expect(Billy::Cache.instance).to receive(:fetch).and_return(status: 200, headers: { 'Connection' => 'close' }, content: 'dynamicCallback1234({"yolo":"kitten"})')
         expect(handler.handle_request(request[:method],
                                       request[:url],
                                       request[:headers],
-                                      request[:body])).to eql({:status=>200, :headers=>{"Connection"=>"close"}, :content=>'dynamicCallback5678({"yolo":"kitten"})'})
+                                      request[:body])).to eql(status: 200, headers: { 'Connection' => 'close' }, content: 'dynamicCallback5678({"yolo":"kitten"})')
       end
 
       it 'is flexible about the format of the response body' do
         expect(Billy::Cache.instance).to receive(:cached?).and_return(true)
-        expect(Billy::Cache.instance).to receive(:fetch).and_return({:status=>200, :headers=>{"Connection"=>"close"}, :content=> "/**/ dynamicCallback1234(\n{\"yolo\":\"kitten\"})"})
+        expect(Billy::Cache.instance).to receive(:fetch).and_return(status: 200, headers: { 'Connection' => 'close' }, content: "/**/ dynamicCallback1234(\n{\"yolo\":\"kitten\"})")
         expect(handler.handle_request(request[:method],
                                       request[:url],
                                       request[:headers],
-                                      request[:body])).to eql({:status=>200, :headers=>{"Connection"=>"close"}, :content=>"/**/ dynamicCallback5678(\n{\"yolo\":\"kitten\"})"})
+                                      request[:body])).to eql(status: 200, headers: { 'Connection' => 'close' }, content: "/**/ dynamicCallback5678(\n{\"yolo\":\"kitten\"})")
       end
 
       it 'does not interfere with non-jsonp requests' do
@@ -78,22 +80,22 @@ describe Billy::CacheHandler do
         other_request = {
           method:  'get',
           url:     'http://example.test:8080/index?hanukkah=latkes',
-          headers: {'Accept-Encoding'=>'gzip', 'Cache-Control'=>'no-cache' },
+          headers: { 'Accept-Encoding' => 'gzip', 'Cache-Control' => 'no-cache' },
           body:    'no jsonp'
         }
 
         allow(Billy::Cache.instance).to receive(:cached?).and_return(true)
-        allow(Billy::Cache.instance).to receive(:fetch).with(jsonp_request[:method], jsonp_request[:url], jsonp_request[:body]).and_return({:status=>200,
-                      :headers=>{"Connection"=>"close"},
-                      :content=> 'dynamicCallback1234({"yolo":"kitten"})'})
-        allow(Billy::Cache.instance).to receive(:fetch).with(other_request[:method], other_request[:url], other_request[:body]).and_return({:status=>200,
-                      :headers=>{"Connection"=>"close"},
-                      :content=> 'no jsonp but has parentheses()'})
+        allow(Billy::Cache.instance).to receive(:fetch).with(jsonp_request[:method], jsonp_request[:url], jsonp_request[:body]).and_return(status: 200,
+                                                                                                                                           headers: { 'Connection' => 'close' },
+                                                                                                                                           content: 'dynamicCallback1234({"yolo":"kitten"})')
+        allow(Billy::Cache.instance).to receive(:fetch).with(other_request[:method], other_request[:url], other_request[:body]).and_return(status: 200,
+                                                                                                                                           headers: { 'Connection' => 'close' },
+                                                                                                                                           content: 'no jsonp but has parentheses()')
 
         expect(handler.handle_request(other_request[:method],
-          other_request[:url],
-          other_request[:headers],
-          other_request[:body])).to eql({:status=>200, :headers=>{"Connection"=>"close"}, :content=>'no jsonp but has parentheses()'})
+                                      other_request[:url],
+                                      other_request[:headers],
+                                      other_request[:body])).to eql(status: 200, headers: { 'Connection' => 'close' }, content: 'no jsonp but has parentheses()')
       end
     end
 
@@ -104,11 +106,11 @@ describe Billy::CacheHandler do
 
       it 'does not change the response' do
         expect(Billy::Cache.instance).to receive(:cached?).and_return(true)
-        expect(Billy::Cache.instance).to receive(:fetch).and_return({:status=>200, :headers=>{"Connection"=>"close"}, :content=> 'dynamicCallback1234({"yolo":"kitten"})'})
+        expect(Billy::Cache.instance).to receive(:fetch).and_return(status: 200, headers: { 'Connection' => 'close' }, content: 'dynamicCallback1234({"yolo":"kitten"})')
         expect(handler.handle_request(request[:method],
                                       request[:url],
                                       request[:headers],
-                                      request[:body])).to eql({:status=>200, :headers=>{"Connection"=>"close"}, :content=>'dynamicCallback1234({"yolo":"kitten"})'})
+                                      request[:body])).to eql(status: 200, headers: { 'Connection' => 'close' }, content: 'dynamicCallback1234({"yolo":"kitten"})')
       end
     end
 

--- a/spec/lib/billy/handlers/handler_spec.rb
+++ b/spec/lib/billy/handlers/handler_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
 describe Billy::Handler do
-  let(:handler) { Class.new{ include Billy::Handler }.new }
+  let(:handler) { Class.new { include Billy::Handler }.new }
   it '#handle_request raises an error if not overridden' do
-    expect(handler.handle_request(nil,nil,nil,nil)).to eql({ error: 'The handler has not overridden the handle_request method!' })
+    expect(handler.handle_request(nil, nil, nil, nil)).to eql(error: 'The handler has not overridden the handle_request method!')
   end
 
   it '#handles_request returns false by default' do
-    expect(handler.handles_request?(nil,nil,nil,nil)).to be false
+    expect(handler.handles_request?(nil, nil, nil, nil)).to be false
   end
 
   it 'responds to #reset' do

--- a/spec/lib/billy/handlers/proxy_handler_spec.rb
+++ b/spec/lib/billy/handlers/proxy_handler_spec.rb
@@ -2,13 +2,15 @@ require 'spec_helper'
 
 describe Billy::ProxyHandler do
   subject { Billy::ProxyHandler.new }
-  let(:request) { {
+  let(:request) do
+    {
       method:   'post',
       url:      'http://example.test:8080/index?some=param',
-      headers:  {'Accept-Encoding'  => 'gzip',
-                 'Cache-Control'    => 'no-cache' },
+      headers:  { 'Accept-Encoding'  => 'gzip',
+                  'Cache-Control'    => 'no-cache' },
       body:     'Some body'
-  } }
+    }
+  end
 
   describe '#handles_request?' do
     context 'with non-whitelisted requests enabled' do
@@ -108,31 +110,31 @@ describe Billy::ProxyHandler do
         header
       end
 
-      let(:em_response)     { double("response") }
-      let(:em_request)      {
-        double("EM::HttpRequest", :error => nil, :response => em_response, :response_header => response_header)
-      }
+      let(:em_response)     { double('response') }
+      let(:em_request)      do
+        double('EM::HttpRequest', error: nil, response: em_response, response_header: response_header)
+      end
 
       before do
         allow(subject).to receive(:handles_request?).and_return(true)
-        allow(em_response).to receive(:force_encoding).and_return("The response body")
+        allow(em_response).to receive(:force_encoding).and_return('The response body')
         allow(EventMachine::HttpRequest).to receive(:new).and_return(em_request)
         expect(em_request).to receive(:post).and_return(em_request)
       end
 
       it 'returns any error in the response' do
-        allow(em_request).to receive(:error).and_return("ERROR!")
+        allow(em_request).to receive(:error).and_return('ERROR!')
         expect(subject.handle_request(request[:method],
                                       request[:url],
                                       request[:headers],
-                                      request[:body])).to eql({ :error => "Request to #{request[:url]} failed with error: ERROR!"})
+                                      request[:body])).to eql(error: "Request to #{request[:url]} failed with error: ERROR!")
       end
 
       it 'returns a hashed response if the request succeeds' do
         expect(subject.handle_request(request[:method],
                                       request[:url],
                                       request[:headers],
-                                      request[:body])).to eql({:status=>200, :headers=>{"Connection"=>"close"}, :content=>"The response body"})
+                                      request[:body])).to eql(status: 200, headers: { 'Connection' => 'close' }, content: 'The response body')
       end
 
       it 'returns nil if both the error and response are for some reason nil' do
@@ -156,10 +158,10 @@ describe Billy::ProxyHandler do
         allow(Billy.config).to receive(:proxied_request_inactivity_timeout).and_return(42)
         allow(Billy.config).to receive(:proxied_request_connect_timeout).and_return(24)
 
-        expect(EventMachine::HttpRequest).to receive(:new).with(request[:url], {
-            inactivity_timeout: 42,
-            connect_timeout: 24
-        })
+        expect(EventMachine::HttpRequest).to receive(:new).with(request[:url],
+                                                                inactivity_timeout: 42,
+                                                                connect_timeout: 24
+        )
 
         subject.handle_request(request[:method],
                                request[:url],

--- a/spec/lib/billy/handlers/request_handler_spec.rb
+++ b/spec/lib/billy/handlers/request_handler_spec.rb
@@ -22,15 +22,17 @@ describe Billy::RequestHandler do
   end
 
   context 'with stubbed handlers' do
-    let(:args) { ["get","url","headers","body"] }
-    let(:stub_handler) { double("StubHandler") }
-    let(:cache_handler) { double("CacheHandler") }
-    let(:proxy_handler) { double("ProxyHandler") }
-    let(:handlers) { {
-        :stubs => stub_handler,
-        :cache => cache_handler,
-        :proxy => proxy_handler
-    } }
+    let(:args) { %w(get url headers body) }
+    let(:stub_handler) { double('StubHandler') }
+    let(:cache_handler) { double('CacheHandler') }
+    let(:proxy_handler) { double('ProxyHandler') }
+    let(:handlers) do
+      {
+        stubs: stub_handler,
+        cache: cache_handler,
+        proxy: proxy_handler
+      }
+    end
 
     before do
       allow(subject).to receive(:handlers).and_return(handlers)
@@ -38,82 +40,82 @@ describe Billy::RequestHandler do
 
     describe '#handles_request?' do
       it 'returns false if no handlers handle the request' do
-        handlers.each do |key,handler|
+        handlers.each do |_key, handler|
           expect(handler).to receive(:handles_request?).with(*args).and_return(false)
         end
         expect(subject.handles_request?(*args)).to be false
       end
 
       it 'returns true immediately if the stub handler handles the request' do
-        expect(stub_handler).to       receive(:handles_request?).with(*args).and_return(true)
-        expect(cache_handler).to_not  receive(:handles_request?)
-        expect(proxy_handler).to_not  receive(:handles_request?)
+        expect(stub_handler).to receive(:handles_request?).with(*args).and_return(true)
+        expect(cache_handler).to_not receive(:handles_request?)
+        expect(proxy_handler).to_not receive(:handles_request?)
         expect(subject.handles_request?(*args)).to be true
       end
 
       it 'returns true if the cache handler handles the request' do
-        expect(stub_handler).to       receive(:handles_request?).with(*args).and_return(false)
-        expect(cache_handler).to      receive(:handles_request?).with(*args).and_return(true)
-        expect(proxy_handler).to_not  receive(:handles_request?)
+        expect(stub_handler).to receive(:handles_request?).with(*args).and_return(false)
+        expect(cache_handler).to receive(:handles_request?).with(*args).and_return(true)
+        expect(proxy_handler).to_not receive(:handles_request?)
         expect(subject.handles_request?(*args)).to be true
       end
 
       it 'returns true if the proxy handler handles the request' do
-        expect(stub_handler).to   receive(:handles_request?).with(*args).and_return(false)
-        expect(cache_handler).to  receive(:handles_request?).with(*args).and_return(false)
-        expect(proxy_handler).to  receive(:handles_request?).with(*args).and_return(true)
+        expect(stub_handler).to receive(:handles_request?).with(*args).and_return(false)
+        expect(cache_handler).to receive(:handles_request?).with(*args).and_return(false)
+        expect(proxy_handler).to receive(:handles_request?).with(*args).and_return(true)
         expect(subject.handles_request?(*args)).to be true
       end
     end
 
     describe '#handle_request' do
       it 'returns stubbed responses' do
-        expect(stub_handler).to       receive(:handle_request).with(*args).and_return("foo")
-        expect(cache_handler).to_not  receive(:handle_request)
-        expect(proxy_handler).to_not  receive(:handle_request)
-        expect(subject.handle_request(*args)).to eql "foo"
+        expect(stub_handler).to receive(:handle_request).with(*args).and_return('foo')
+        expect(cache_handler).to_not receive(:handle_request)
+        expect(proxy_handler).to_not receive(:handle_request)
+        expect(subject.handle_request(*args)).to eql 'foo'
       end
 
       it 'returns cached responses' do
-        expect(stub_handler).to       receive(:handle_request).with(*args)
-        expect(cache_handler).to      receive(:handle_request).with(*args).and_return("bar")
-        expect(proxy_handler).to_not  receive(:handle_request)
-        expect(subject.handle_request(*args)).to eql "bar"
+        expect(stub_handler).to receive(:handle_request).with(*args)
+        expect(cache_handler).to receive(:handle_request).with(*args).and_return('bar')
+        expect(proxy_handler).to_not receive(:handle_request)
+        expect(subject.handle_request(*args)).to eql 'bar'
       end
 
       it 'returns proxied responses' do
-        expect(stub_handler).to       receive(:handle_request).with(*args)
-        expect(cache_handler).to      receive(:handle_request).with(*args)
-        expect(proxy_handler).to      receive(:handle_request).with(*args).and_return("baz")
-        expect(subject.handle_request(*args)).to eql "baz"
+        expect(stub_handler).to receive(:handle_request).with(*args)
+        expect(cache_handler).to receive(:handle_request).with(*args)
+        expect(proxy_handler).to receive(:handle_request).with(*args).and_return('baz')
+        expect(subject.handle_request(*args)).to eql 'baz'
       end
 
       it 'returns an error hash if request is not handled' do
-        expect(stub_handler).to       receive(:handle_request).with(*args)
-        expect(cache_handler).to      receive(:handle_request).with(*args)
-        expect(proxy_handler).to      receive(:handle_request).with(*args)
-        expect(subject.handle_request(*args)).to eql({ :error => "Connection to url not cached and new http connections are disabled" })
+        expect(stub_handler).to receive(:handle_request).with(*args)
+        expect(cache_handler).to receive(:handle_request).with(*args)
+        expect(proxy_handler).to receive(:handle_request).with(*args)
+        expect(subject.handle_request(*args)).to eql(error: 'Connection to url not cached and new http connections are disabled')
       end
 
       it 'returns an error hash with body message if POST request is not handled' do
         args[0] = 'post'
-        expect(stub_handler).to       receive(:handle_request).with(*args)
-        expect(cache_handler).to      receive(:handle_request).with(*args)
-        expect(proxy_handler).to      receive(:handle_request).with(*args)
-        expect(subject.handle_request(*args)).to eql({ :error => "Connection to url with body 'body' not cached and new http connections are disabled" })
+        expect(stub_handler).to receive(:handle_request).with(*args)
+        expect(cache_handler).to receive(:handle_request).with(*args)
+        expect(proxy_handler).to receive(:handle_request).with(*args)
+        expect(subject.handle_request(*args)).to eql(error: "Connection to url with body 'body' not cached and new http connections are disabled")
       end
     end
 
     describe '#stub' do
       it 'delegates to the stub_handler' do
-        expect(stub_handler).to receive(:stub).with("some args")
-        subject.stub("some args")
+        expect(stub_handler).to receive(:stub).with('some args')
+        subject.stub('some args')
       end
     end
 
     describe '#reset' do
       it 'resets all of the handlers' do
-        handlers.each do |key,handler|
+        handlers.each do |_key, handler|
           expect(handler).to receive(:reset)
         end
         subject.reset

--- a/spec/lib/billy/handlers/stub_handler_spec.rb
+++ b/spec/lib/billy/handlers/stub_handler_spec.rb
@@ -2,42 +2,44 @@ require 'spec_helper'
 
 describe Billy::StubHandler do
   let(:handler) { Billy::StubHandler.new }
-  let(:request) { {
+  let(:request) do
+    {
       method:   'GET',
       url:      'http://example.test:8080/index?some=param',
-      headers:  {'Accept-Encoding'  => 'gzip',
-                 'Cache-Control'    => 'no-cache' },
+      headers:  { 'Accept-Encoding'  => 'gzip',
+                  'Cache-Control'    => 'no-cache' },
       body:     'Some body'
-  } }
+    }
+  end
 
   describe '#handles_request?' do
     it 'handles the request if it is stubbed' do
-      expect(handler).to receive(:find_stub).and_return("a stub")
-      expect(handler.handles_request?(nil,nil,nil,nil)).to be true
+      expect(handler).to receive(:find_stub).and_return('a stub')
+      expect(handler.handles_request?(nil, nil, nil, nil)).to be true
     end
 
     it 'does not handle the request if it is not stubbed' do
       expect(handler).to receive(:find_stub).and_return(nil)
-      expect(handler.handles_request?(nil,nil,nil,nil)).to be false
+      expect(handler.handles_request?(nil, nil, nil, nil)).to be false
     end
   end
 
   describe '#handle_request' do
     it 'returns nil if the request is not stubbed' do
       expect(handler).to receive(:handles_request?).and_return(false)
-      expect(handler.handle_request(nil,nil,nil,nil)).to be nil
+      expect(handler.handle_request(nil, nil, nil, nil)).to be nil
     end
 
     it 'returns a response hash if the request is stubbed' do
-      stub = double("stub", :call => [200, {'Content-Type' => 'application/json'}, "Some content"])
+      stub = double('stub', call: [200, { 'Content-Type' => 'application/json' }, 'Some content'])
       expect(handler).to receive(:handles_request?).and_return(true)
       expect(handler).to receive(:find_stub).and_return(stub)
       expect(handler.handle_request('GET',
                                     request[:url],
                                     request[:headers],
-                                    request[:body])).to eql({:status => 200,
-                                                             :headers => {'Content-Type' => 'application/json'},
-                                                             :content => "Some content"})
+                                    request[:body])).to eql(status: 200,
+                                                            headers: { 'Content-Type' => 'application/json' },
+                                                            content: 'Some content')
     end
   end
 

--- a/spec/lib/billy/proxy_request_stub_spec.rb
+++ b/spec/lib/billy/proxy_request_stub_spec.rb
@@ -3,27 +3,27 @@ require 'spec_helper'
 describe Billy::ProxyRequestStub do
   context '#matches?' do
     it 'should match urls and methods' do
-      expect(Billy::ProxyRequestStub.new('http://example.com').
-        matches?('GET', 'http://example.com')).to be
-      expect(Billy::ProxyRequestStub.new('http://example.com').
-        matches?('POST', 'http://example.com')).to_not be
+      expect(Billy::ProxyRequestStub.new('http://example.com')
+        .matches?('GET', 'http://example.com')).to be
+      expect(Billy::ProxyRequestStub.new('http://example.com')
+        .matches?('POST', 'http://example.com')).to_not be
 
-      expect(Billy::ProxyRequestStub.new('http://example.com', :method => :get).
-        matches?('GET', 'http://example.com')).to be
-      expect(Billy::ProxyRequestStub.new('http://example.com', :method => :post).
-        matches?('GET', 'http://example.com')).to_not be
+      expect(Billy::ProxyRequestStub.new('http://example.com', method: :get)
+        .matches?('GET', 'http://example.com')).to be
+      expect(Billy::ProxyRequestStub.new('http://example.com', method: :post)
+        .matches?('GET', 'http://example.com')).to_not be
 
-      expect(Billy::ProxyRequestStub.new('http://example.com', :method => :post).
-        matches?('POST', 'http://example.com')).to be
-      expect(Billy::ProxyRequestStub.new('http://fooxample.com', :method => :post).
-        matches?('POST', 'http://example.com')).to_not be
+      expect(Billy::ProxyRequestStub.new('http://example.com', method: :post)
+        .matches?('POST', 'http://example.com')).to be
+      expect(Billy::ProxyRequestStub.new('http://fooxample.com', method: :post)
+        .matches?('POST', 'http://example.com')).to_not be
     end
 
     it 'should match regexps' do
-      expect(Billy::ProxyRequestStub.new(/http:\/\/.+\.com/, :method => :post).
-        matches?('POST', 'http://example.com')).to be
-      expect(Billy::ProxyRequestStub.new(/http:\/\/.+\.co\.uk/, :method => :get).
-        matches?('GET', 'http://example.com')).to_not be
+      expect(Billy::ProxyRequestStub.new(/http:\/\/.+\.com/, method: :post)
+        .matches?('POST', 'http://example.com')).to be
+      expect(Billy::ProxyRequestStub.new(/http:\/\/.+\.co\.uk/, method: :get)
+        .matches?('GET', 'http://example.com')).to_not be
     end
 
     it 'should match up to but not including query strings' do
@@ -34,11 +34,11 @@ describe Billy::ProxyRequestStub do
     end
   end
 
-  context "#call (without #and_return)" do
+  context '#call (without #and_return)' do
     let(:subject) { Billy::ProxyRequestStub.new('url') }
 
-    it "returns a 204 empty response" do
-      expect(subject.call({}, {}, nil)).to eql [204, {"Content-Type" => "text/plain"}, ""]
+    it 'returns a 204 empty response' do
+      expect(subject.call({}, {}, nil)).to eql [204, { 'Content-Type' => 'text/plain' }, '']
     end
   end
 
@@ -46,7 +46,7 @@ describe Billy::ProxyRequestStub do
     let(:subject) { Billy::ProxyRequestStub.new('url') }
 
     it 'should generate bare responses' do
-      subject.and_return :body => 'baz foo bar'
+      subject.and_return body: 'baz foo bar'
       expect(subject.call({}, {}, nil)).to eql [
         200,
         {},
@@ -55,75 +55,75 @@ describe Billy::ProxyRequestStub do
     end
 
     it 'should generate text responses' do
-      subject.and_return :text => 'foo bar baz'
+      subject.and_return text: 'foo bar baz'
       expect(subject.call({}, {}, nil)).to eql [
         200,
-        {'Content-Type' => 'text/plain'},
+        { 'Content-Type' => 'text/plain' },
         'foo bar baz'
       ]
     end
 
     it 'should generate JSON responses' do
-      subject.and_return :json => { :foo => 'bar' }
+      subject.and_return json: { foo: 'bar' }
       expect(subject.call({}, {}, nil)).to eql [
         200,
-        {'Content-Type' => 'application/json'},
+        { 'Content-Type' => 'application/json' },
         '{"foo":"bar"}'
       ]
     end
 
     context 'JSONP' do
       it 'should generate JSONP responses' do
-        subject.and_return :jsonp => { :foo => 'bar' }
+        subject.and_return jsonp: { foo: 'bar' }
         expect(subject.call({ 'callback' => ['baz'] }, {}, nil)).to eql [
           200,
-          {'Content-Type' => 'application/javascript'},
+          { 'Content-Type' => 'application/javascript' },
           'baz({"foo":"bar"})'
         ]
       end
 
       it 'should generate JSONP responses with custom callback parameter' do
-        subject.and_return :jsonp => { :foo => 'bar' }, :callback_param => 'cb'
+        subject.and_return jsonp: { foo: 'bar' }, callback_param: 'cb'
         expect(subject.call({ 'cb' => ['bap'] }, {}, nil)).to eql [
           200,
-          {'Content-Type' => 'application/javascript'},
+          { 'Content-Type' => 'application/javascript' },
           'bap({"foo":"bar"})'
         ]
       end
 
       it 'should generate JSONP responses with custom callback name' do
-        subject.and_return :jsonp => { :foo => 'bar' }, :callback => 'cb'
+        subject.and_return jsonp: { foo: 'bar' }, callback: 'cb'
         expect(subject.call({}, {}, nil)).to eql [
           200,
-          {'Content-Type' => 'application/javascript'},
+          { 'Content-Type' => 'application/javascript' },
           'cb({"foo":"bar"})'
         ]
       end
     end
 
     it 'should generate redirection responses' do
-      subject.and_return :redirect_to => 'http://example.com'
+      subject.and_return redirect_to: 'http://example.com'
       expect(subject.call({}, {}, nil)).to eql [
         302,
-        {'Location' => 'http://example.com'},
+        { 'Location' => 'http://example.com' },
         nil
       ]
     end
 
     it 'should set headers' do
-      subject.and_return :text => 'foo', :headers => {'HTTP-X-Foo' => 'bar'}
+      subject.and_return text: 'foo', headers: { 'HTTP-X-Foo' => 'bar' }
       expect(subject.call({}, {}, nil)).to eql [
         200,
-        {'Content-Type' => 'text/plain', 'HTTP-X-Foo' => 'bar'},
+        { 'Content-Type' => 'text/plain', 'HTTP-X-Foo' => 'bar' },
         'foo'
       ]
     end
 
     it 'should set status codes' do
-      subject.and_return :text => 'baz', :code => 410
+      subject.and_return text: 'baz', code: 410
       expect(subject.call({}, {}, nil)).to eql [
         410,
-        {'Content-Type' => 'text/plain'},
+        { 'Content-Type' => 'text/plain' },
         'baz'
       ]
     end
@@ -133,15 +133,15 @@ describe Billy::ProxyRequestStub do
       expected_headers = { 'header1' => 'three', 'header2' => 'four' }
       expected_body = 'body text'
 
-      subject.and_return(Proc.new { |params, headers, body|
+      subject.and_return(proc do |params, headers, body|
         expect(params).to eql expected_params
         expect(headers).to eql expected_headers
         expect(body).to eql 'body text'
-        {:code => 418, :text => 'success'}
-      })
+        { code: 418, text: 'success' }
+      end)
       expect(subject.call(expected_params, expected_headers, expected_body)).to eql [
         418,
-        {'Content-Type' => 'text/plain'},
+        { 'Content-Type' => 'text/plain' },
         'success'
       ]
     end

--- a/spec/lib/billy/resource_utils_spec.rb
+++ b/spec/lib/billy/resource_utils_spec.rb
@@ -4,31 +4,31 @@ describe Billy::JSONUtils do
   describe 'sorting' do
     describe '#sort_hash_keys' do
       it 'sorts simple Hashes' do
-        data     = {c: 'three',a: 'one',b: 'two'}
-        expected = {a: 'one',b: 'two',c: 'three'}
-        expect(Billy::JSONUtils::sort_hash_keys(data)).to eq expected
+        data     = { c: 'three', a: 'one', b: 'two' }
+        expected = { a: 'one', b: 'two', c: 'three' }
+        expect(Billy::JSONUtils.sort_hash_keys(data)).to eq expected
       end
 
       it 'does not sort simple Arrays' do
-        data     = [3,1,2,'two','three','one']
-        expect(Billy::JSONUtils::sort_hash_keys(data)).to eq data
+        data     = [3, 1, 2, 'two', 'three', 'one']
+        expect(Billy::JSONUtils.sort_hash_keys(data)).to eq data
       end
 
       it 'does not sort multi-dimensional Arrays' do
-        data     = [[3,2,1],[5,4,6],['b','c','a']]
-        expect(Billy::JSONUtils::sort_hash_keys(data)).to eq data
+        data     = [[3, 2, 1], [5, 4, 6], %w(b c a)]
+        expect(Billy::JSONUtils.sort_hash_keys(data)).to eq data
       end
 
       it 'sorts multi-dimensional Hashes' do
-        data     = {c: {l: 2,m: 3,k: 1},a: {f: 3,e: 2,d: 1},b: {i: 2,h: 1,j: 3}}
-        expected = {a: {d: 1,e: 2,f: 3},b: {h: 1,i: 2,j: 3},c: {k: 1,l: 2,m: 3}}
-        expect(Billy::JSONUtils::sort_hash_keys(data)).to eq expected
+        data     = { c: { l: 2, m: 3, k: 1 }, a: { f: 3, e: 2, d: 1 }, b: { i: 2, h: 1, j: 3 } }
+        expected = { a: { d: 1, e: 2, f: 3 }, b: { h: 1, i: 2, j: 3 }, c: { k: 1, l: 2, m: 3 } }
+        expect(Billy::JSONUtils.sort_hash_keys(data)).to eq expected
       end
 
       it 'sorts abnormal data structures' do
-        data     = {b: [['b','c','a'],{ab: 5,aa: 4, ac: 6},[3,2,1],{ba: true,bc: false, bb: nil}],a: {f: 3,e: 2,d: 1}}
-        expected = {a: {d: 1,e: 2,f: 3},b: [['b','c','a'],{aa: 4,ab: 5,ac: 6},[3,2,1],{ba: true, bb: nil,bc: false}]}
-        expect(Billy::JSONUtils::sort_hash_keys(data)).to eq expected
+        data     = { b: [%w(b c a), { ab: 5, aa: 4, ac: 6 }, [3, 2, 1], { ba: true, bc: false, bb: nil }], a: { f: 3, e: 2, d: 1 } }
+        expected = { a: { d: 1, e: 2, f: 3 }, b: [%w(b c a), { aa: 4, ab: 5, ac: 6 }, [3, 2, 1], { ba: true, bb: nil, bc: false }] }
+        expect(Billy::JSONUtils.sort_hash_keys(data)).to eq expected
       end
     end
 
@@ -36,20 +36,20 @@ describe Billy::JSONUtils do
       it 'sorts JSON' do
         data     = '{"c":"three","a":"one","b":"two"}'
         expected = '{"a":"one","b":"two","c":"three"}'
-        expect(Billy::JSONUtils::sort_json(data)).to eq expected
+        expect(Billy::JSONUtils.sort_json(data)).to eq expected
       end
     end
   end
 
   describe 'json?' do
-    let(:json) { {a: '1'}.to_json }
+    let(:json) { { a: '1' }.to_json }
     let(:non_json) { 'Not JSON.' }
 
     it 'identifies JSON' do
-      expect(Billy::JSONUtils::json?(json)).to be true
+      expect(Billy::JSONUtils.json?(json)).to be true
     end
     it 'identifies non-JSON' do
-      expect(Billy::JSONUtils::json?(non_json)).to be false
+      expect(Billy::JSONUtils.json?(non_json)).to be false
     end
   end
 end

--- a/spec/lib/proxy_spec.rb
+++ b/spec/lib/proxy_spec.rb
@@ -8,11 +8,11 @@ shared_examples_for 'a proxy server' do
   end
 
   it 'should proxy POST requests' do
-    expect(http.post('/echo', :foo => 'bar').body).to eql "POST /echo\nfoo=bar"
+    expect(http.post('/echo', foo: 'bar').body).to eql "POST /echo\nfoo=bar"
   end
 
   it 'should proxy PUT requests' do
-    expect(http.post('/echo', :foo => 'bar').body).to eql "POST /echo\nfoo=bar"
+    expect(http.post('/echo', foo: 'bar').body).to eql "POST /echo\nfoo=bar"
   end
 
   it 'should proxy HEAD requests' do
@@ -26,44 +26,43 @@ end
 
 shared_examples_for 'a request stub' do
   it 'should stub GET requests' do
-    proxy.stub("#{url}/foo").
-      and_return(:text => 'hello, GET!')
+    proxy.stub("#{url}/foo")
+      .and_return(text: 'hello, GET!')
     expect(http.get('/foo').body).to eql 'hello, GET!'
   end
 
   it 'should stub GET response statuses' do
-    proxy.stub("#{url}/foo").
-      and_return(:code => 200)
+    proxy.stub("#{url}/foo")
+      .and_return(code: 200)
     expect(http.get('/foo').status).to eql 200
   end
 
   it 'should stub POST requests' do
-    proxy.stub("#{url}/bar", :method => :post).
-      and_return(:text => 'hello, POST!')
-    expect(http.post('/bar', :foo => :bar).body).to eql 'hello, POST!'
+    proxy.stub("#{url}/bar", method: :post)
+      .and_return(text: 'hello, POST!')
+    expect(http.post('/bar', foo: :bar).body).to eql 'hello, POST!'
   end
 
   it 'should stub PUT requests' do
-    proxy.stub("#{url}/baz", :method => :put).
-      and_return(:text => 'hello, PUT!')
-    expect(http.put('/baz', :foo => :bar).body).to eql 'hello, PUT!'
+    proxy.stub("#{url}/baz", method: :put)
+      .and_return(text: 'hello, PUT!')
+    expect(http.put('/baz', foo: :bar).body).to eql 'hello, PUT!'
   end
 
   it 'should stub HEAD requests' do
-    proxy.stub("#{url}/bap", :method => :head).
-      and_return(:headers => {'HTTP-X-Hello' => 'hello, HEAD!'})
+    proxy.stub("#{url}/bap", method: :head)
+      .and_return(headers: { 'HTTP-X-Hello' => 'hello, HEAD!' })
     expect(http.head('/bap').headers['http-x-hello']).to eql 'hello, HEAD!'
   end
 
   it 'should stub DELETE requests' do
-    proxy.stub("#{url}/bam", :method => :delete).
-      and_return(:text => 'hello, DELETE!')
+    proxy.stub("#{url}/bam", method: :delete)
+      .and_return(text: 'hello, DELETE!')
     expect(http.delete('/bam').body).to eql 'hello, DELETE!'
   end
 end
 
 shared_examples_for 'a cache' do
-
   context 'whitelisted GET requests' do
     it 'should not be cached' do
       assert_noncached_url
@@ -93,7 +92,7 @@ shared_examples_for 'a cache' do
     context 'with ports' do
       before do
         rack_app_url = URI(http.url_prefix)
-        Billy.config.whitelist = ["#{rack_app_url.host}:#{rack_app_url.port+1}"]
+        Billy.config.whitelist = ["#{rack_app_url.host}:#{rack_app_url.port + 1}"]
       end
 
       it 'should be cached' do
@@ -110,11 +109,11 @@ shared_examples_for 'a cache' do
     it 'should be cached' do
       r = http.get('/analytics?some_param=5')
       expect(r.body).to eql 'GET /analytics'
-      expect {
-        expect {
+      expect do
+        expect do
           r = http.get('/analytics?some_param=20')
-        }.to change { r.headers['HTTP-X-EchoCount'].to_i }.by(1)
-      }.to_not change { r.body }
+        end.to change { r.headers['HTTP-X-EchoCount'].to_i }.by(1)
+      end.to_not change { r.body }
     end
   end
 
@@ -128,11 +127,11 @@ shared_examples_for 'a cache' do
     end
   end
 
-  context "cache persistence" do
+  context 'cache persistence' do
     let(:cache_path) { Billy.config.cache_path }
-    let(:cached_key) { proxy.cache.key('get',"#{url}/foo","") }
+    let(:cached_key) { proxy.cache.key('get', "#{url}/foo", '') }
     let(:cached_file) do
-      f = cached_key + ".yml"
+      f = cached_key + '.yml'
       File.join(cache_path, f)
     end
 
@@ -142,24 +141,24 @@ shared_examples_for 'a cache' do
     end
 
     after do
-      File.delete(cached_file) if File.exists?(cached_file)
+      File.delete(cached_file) if File.exist?(cached_file)
     end
 
-    context "enabled" do
+    context 'enabled' do
       before { Billy.config.persist_cache = true }
 
       it 'should persist' do
         r = http.get('/foo')
-        expect(File.exists?(cached_file)).to be true
+        expect(File.exist?(cached_file)).to be true
       end
 
       it 'should be read initially from persistent cache' do
         File.open(cached_file, 'w') do |f|
           cached = {
-            :headers => {},
-            :content => "GET /foo cached"
+            headers: {},
+            content: 'GET /foo cached'
           }
-          f.write(cached.to_yaml(:Encoding => :Utf8))
+          f.write(cached.to_yaml(Encoding: :Utf8))
         end
 
         r = http.get('/foo')
@@ -201,8 +200,8 @@ shared_examples_for 'a cache' do
         before { Billy.config.non_whitelisted_requests_disabled = true }
 
         it 'should raise error when disabled' do
-          #TODO: Suppress stderr output: https://gist.github.com/adamstegman/926858
-          expect{http.get('/foo')}.to raise_error(Faraday::Error::ConnectionFailed, "end of file reached")
+          # TODO: Suppress stderr output: https://gist.github.com/adamstegman/926858
+          expect { http.get('/foo') }.to raise_error(Faraday::Error::ConnectionFailed, 'end of file reached')
         end
       end
 
@@ -215,7 +214,7 @@ shared_examples_for 'a cache' do
 
         it 'should not cache non-successful response when enabled' do
           http_error.get('/foo')
-          expect(File.exists?(cached_file)).to be false
+          expect(File.exist?(cached_file)).to be false
         end
 
         it 'should cache successful response when enabled' do
@@ -238,22 +237,21 @@ shared_examples_for 'a cache' do
           # 2) Restart the test servers if they aren't running
           # 3) Change the test servers to start/stop for each test instead of before all
           # 4) Remove the test server completely and rely on the server instantiated by the app
-          pending "Unable to test this without affecting the running test servers"
+          pending 'Unable to test this without affecting the running test servers'
           # If the 'pending' continues to execute the spec, 'skip' it to avoid EM errors.
           # If 'pending' stops the test, 'skip' isn't defined but it won't hit this line.
-          skip "Unable to test this without affecting the running test servers"
-          expect{http_error.get('/foo')}.to raise_error(Faraday::Error::ConnectionFailed)
+          skip 'Unable to test this without affecting the running test servers'
+          expect { http_error.get('/foo') }.to raise_error(Faraday::Error::ConnectionFailed)
         end
       end
-
     end
 
-    context "disabled" do
+    context 'disabled' do
       before { Billy.config.persist_cache = false }
 
       it 'shouldnt persist' do
         r = http.get('/foo')
-        expect(File.exists?(cached_file)).to be false
+        expect(File.exist?(cached_file)).to be false
       end
     end
   end
@@ -261,41 +259,39 @@ shared_examples_for 'a cache' do
   def assert_noncached_url(url = '/foo')
     r = http.get(url)
     expect(r.body).to eql "GET #{url}"
-    expect {
-      expect {
+    expect do
+      expect do
         r = http.get(url)
-      }.to change { r.headers['HTTP-X-EchoCount'].to_i }.by(1)
-    }.to_not change { r.body }
+      end.to change { r.headers['HTTP-X-EchoCount'].to_i }.by(1)
+    end.to_not change { r.body }
   end
 
   def assert_cached_url(url = '/foo')
     r = http.get(url)
     expect(r.body).to eql "GET #{url}"
-    expect {
-      expect {
+    expect do
+      expect do
         r = http.get(url)
-      }.to_not change { r.headers['HTTP-X-EchoCount'] }
-    }.to_not change { r.body }
+      end.to_not change { r.headers['HTTP-X-EchoCount'] }
+    end.to_not change { r.body }
   end
 end
 
 describe Billy::Proxy do
-
   before do
     # Adding non-valid Faraday options throw an error: https://github.com/arsduo/koala/pull/311
     # Valid options: :request, :proxy, :ssl, :builder, :url, :parallel_manager, :params, :headers, :builder_class
     faraday_options = {
-      :proxy   => { :uri => proxy.url },
-      :request => { :timeout => 1.0 }
+      proxy: { uri: proxy.url },
+      request: { timeout: 1.0 }
     }
 
     @http       = Faraday.new @http_url,  faraday_options
-    @https      = Faraday.new @https_url, faraday_options.merge(:ssl => { :verify => false })
+    @https      = Faraday.new @https_url, faraday_options.merge(ssl: { verify: false })
     @http_error = Faraday.new @error_url, faraday_options
   end
 
   context 'proxying' do
-
     context 'HTTP' do
       let!(:http) { @http }
       it_should_behave_like 'a proxy server'
@@ -305,11 +301,9 @@ describe Billy::Proxy do
       let!(:http) { @https }
       it_should_behave_like 'a proxy server'
     end
-
   end
 
   context 'stubbing' do
-
     context 'HTTP' do
       let!(:url)  { @http_url }
       let!(:http) { @http }
@@ -321,11 +315,9 @@ describe Billy::Proxy do
       let!(:http) { @https }
       it_should_behave_like 'a request stub'
     end
-
   end
 
   context 'caching' do
-
     it 'defaults to nil scope' do
       expect(proxy.cache.scope).to be nil
     end
@@ -350,7 +342,7 @@ describe Billy::Proxy do
       let!(:http_error) { @http_error }
 
       before do
-        proxy.cache.scope_to "my_cache"
+        proxy.cache.scope_to 'my_cache'
       end
 
       after do
@@ -360,7 +352,7 @@ describe Billy::Proxy do
       it_should_behave_like 'a cache'
 
       it 'uses the cache scope' do
-        expect(proxy.cache.scope).to eq("my_cache")
+        expect(proxy.cache.scope).to eq('my_cache')
       end
 
       it 'can be reset to the default scope' do
@@ -369,21 +361,21 @@ describe Billy::Proxy do
       end
 
       it 'can execute a block against a cache scope' do
-        expect(proxy.cache.scope).to eq "my_cache"
-        proxy.cache.with_scope "another_cache" do
-          expect(proxy.cache.scope).to eq "another_cache"
+        expect(proxy.cache.scope).to eq 'my_cache'
+        proxy.cache.with_scope 'another_cache' do
+          expect(proxy.cache.scope).to eq 'another_cache'
         end
-        expect(proxy.cache.scope).to eq "my_cache"
+        expect(proxy.cache.scope).to eq 'my_cache'
       end
 
       it 'requires a block to be passed to with_scope' do
-        expect {proxy.cache.with_scope "some_scope"}.to raise_error ArgumentError
+        expect { proxy.cache.with_scope 'some_scope' }.to raise_error ArgumentError
       end
 
       it 'should have different keys for the same request under a different scope' do
-        args = ['get',"#{url}/foo",""]
+        args = ['get', "#{url}/foo", '']
         key = proxy.cache.key(*args)
-        proxy.cache.with_scope "another_cache" do
+        proxy.cache.with_scope 'another_cache' do
           expect(proxy.cache.key(*args)).to_not eq key
         end
       end

--- a/spec/lib/proxy_spec.rb
+++ b/spec/lib/proxy_spec.rb
@@ -148,7 +148,7 @@ shared_examples_for 'a cache' do
       before { Billy.config.persist_cache = true }
 
       it 'should persist' do
-        r = http.get('/foo')
+        http.get('/foo')
         expect(File.exist?(cached_file)).to be true
       end
 
@@ -167,7 +167,7 @@ shared_examples_for 'a cache' do
 
       context 'cache_request_headers requests' do
         it 'should not be cached by default' do
-          r = http.get('/foo')
+          http.get('/foo')
           saved_cache = Billy.proxy.cache.fetch_from_persistence(cached_key)
           expect(saved_cache.keys).not_to include :request_headers
         end
@@ -178,7 +178,7 @@ shared_examples_for 'a cache' do
           end
 
           it 'should be cached' do
-            r = http.get('/foo')
+            http.get('/foo')
             saved_cache = Billy.proxy.cache.fetch_from_persistence(cached_key)
             expect(saved_cache.keys).to include :request_headers
           end
@@ -250,7 +250,7 @@ shared_examples_for 'a cache' do
       before { Billy.config.persist_cache = false }
 
       it 'shouldnt persist' do
-        r = http.get('/foo')
+        http.get('/foo')
         expect(File.exist?(cached_file)).to be false
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,15 @@
-Dir[File.expand_path("../support/**/*.rb", __FILE__)].each {|f| require f}
+Dir[File.expand_path('../support/**/*.rb', __FILE__)].each { |f| require f }
 
 require 'pry'
 require 'billy/rspec'
 require 'rack'
 require 'logger'
 
-Capybara.app = Rack::Directory.new(File.expand_path("../../examples", __FILE__))
+Capybara.app = Rack::Directory.new(File.expand_path('../../examples', __FILE__))
 Capybara.javascript_driver = :poltergeist_billy
 
 Billy.configure do |config|
-  config.logger = Logger.new(File.expand_path("../../log/test.log", __FILE__))
+  config.logger = Logger.new(File.expand_path('../../log/test.log', __FILE__))
 end
 
 RSpec.configure do |config|

--- a/spec/support/test_server.rb
+++ b/spec/support/test_server.rb
@@ -42,7 +42,7 @@ module Billy
 
     def echo_app_setup(response_code = 200)
       counter = 0
-      proc do |env|
+      Proc.new do |env|
         req_body = env['rack.input'].read
         request_info = "#{env['REQUEST_METHOD']} #{env['PATH_INFO']}"
         res_body = request_info

--- a/spec/support/test_server.rb
+++ b/spec/support/test_server.rb
@@ -42,7 +42,7 @@ module Billy
 
     def echo_app_setup(response_code = 200)
       counter = 0
-      Proc.new do |env|
+      proc do |env|
         req_body = env['rack.input'].read
         request_info = "#{env['REQUEST_METHOD']} #{env['PATH_INFO']}"
         res_body = request_info
@@ -62,8 +62,8 @@ module Billy
       if ssl
         http_server.ssl = true
         http_server.ssl_options = {
-          :private_key_file => File.expand_path('../../fixtures/test-server.key', __FILE__),
-          :cert_chain_file => File.expand_path('../../fixtures/test-server.crt', __FILE__)
+          private_key_file: File.expand_path('../../fixtures/test-server.key', __FILE__),
+          cert_chain_file: File.expand_path('../../fixtures/test-server.crt', __FILE__)
         }
       end
       http_server.start


### PR DESCRIPTION
Mainly removing hash rockets, spacing adjustments, and single quotes over double quotes.