### PR TITLE
#21 #42 Create option for strip query params in request stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ they use cache avoidance techniques, but return practically the same response
 that most often does not affect your test results.
 
 `c.strip_query_params` is used to strip query parameters when you stub some requests
-with query parameters. Default value is false. For example, `proxy.stub('http://myapi.com/user/?country=FOO')`
+with query parameters. Default value is true. For example, `proxy.stub('http://myapi.com/user/?country=FOO')`
 is considered the same as: `proxy.stub('http://myapi.com/user/?anything=FOO')` and
 generally the same as: `proxy.stub('http://myapi.com/user/')`. When you need to distinguish between all these requests,
 you may set this config value to false.

--- a/README.md
+++ b/README.md
@@ -202,6 +202,12 @@ caching. You should mostly use this for analytics and various social buttons as
 they use cache avoidance techniques, but return practically the same response
 that most often does not affect your test results.
 
+`c.strip_query_params` is used to strip query parameters when you stub some requests
+with query parameters. Default value is false. For example, `proxy.stub('http://myapi.com/user/?country=FOO')`
+is considered the same as: `proxy.stub('http://myapi.com/user/?anything=FOO')` and
+generally the same as: `proxy.stub('http://myapi.com/user/')`. When you need to distinguish between all these requests,
+you may set this config value to false.
+
 `c.dynamic_jsonp` is used to rewrite the body of JSONP responses based on the
 callback parameter. For example, if a request to `http://example.com/foo?callback=bar` 
 returns `bar({"some": "json"});` and is recorded, then a later request to

--- a/lib/billy/config.rb
+++ b/lib/billy/config.rb
@@ -9,7 +9,8 @@ module Billy
     attr_accessor :logger, :cache, :cache_request_headers, :whitelist, :path_blacklist, :ignore_params,
                   :persist_cache, :ignore_cache_port, :non_successful_cache_disabled, :non_successful_error_level,
                   :non_whitelisted_requests_disabled, :cache_path, :proxy_port, :proxied_request_inactivity_timeout,
-                  :proxied_request_connect_timeout, :dynamic_jsonp, :dynamic_jsonp_keys, :merge_cached_responses_whitelist
+                  :proxied_request_connect_timeout, :dynamic_jsonp, :dynamic_jsonp_keys, :merge_cached_responses_whitelist,
+                  :strip_query_params
 
     def initialize
       @logger = defined?(Rails) ? Rails.logger : Logger.new(STDOUT)
@@ -34,6 +35,7 @@ module Billy
       @proxy_port = RANDOM_AVAILABLE_PORT
       @proxied_request_inactivity_timeout = 10 # defaults from https://github.com/igrigorik/em-http-request/wiki/Redirects-and-Timeouts
       @proxied_request_connect_timeout = 5
+      @strip_query_params = true
     end
   end
 

--- a/lib/billy/proxy_request_stub.rb
+++ b/lib/billy/proxy_request_stub.rb
@@ -57,7 +57,7 @@ module Billy
         if @url.is_a?(Regexp)
           url.match(@url)
         else
-          url.split('?')[0] == @url
+          Billy.config.strip_query_params ? (url.split('?')[0] == @url) : (url == @url)
         end
       end
     end

--- a/spec/lib/billy/proxy_request_stub_spec.rb
+++ b/spec/lib/billy/proxy_request_stub_spec.rb
@@ -39,10 +39,17 @@ describe Billy::ProxyRequestStub do
       Billy.config.strip_query_params = false
     end
 
-    it 'should match up to and including query strings' do
+    it 'should not match up to request with query strings' do
       stub = Billy::ProxyRequestStub.new('http://example.com/foo/bar/')
       expect(stub.matches?('GET', 'http://example.com/foo/')).to_not be
       expect(stub.matches?('GET', 'http://example.com/foo/bar/')).to be
+      expect(stub.matches?('GET', 'http://example.com/foo/bar/?baz=bap')).to_not be
+    end
+
+    it 'should match up only to the same request' do
+      stub = Billy::ProxyRequestStub.new('http://example.com/foo/?baz=bap')
+      expect(stub.matches?('GET', 'http://example.com/foo/')).to_not be
+      expect(stub.matches?('GET', 'http://example.com/foo/?baz=bap')).to be
       expect(stub.matches?('GET', 'http://example.com/foo/bar/?baz=bap')).to_not be
     end
   end

--- a/spec/lib/billy/proxy_request_stub_spec.rb
+++ b/spec/lib/billy/proxy_request_stub_spec.rb
@@ -45,13 +45,6 @@ describe Billy::ProxyRequestStub do
       expect(stub.matches?('GET', 'http://example.com/foo/bar/')).to be
       expect(stub.matches?('GET', 'http://example.com/foo/bar/?baz=bap')).to_not be
     end
-
-    it 'should match up only to the same request' do
-      stub = Billy::ProxyRequestStub.new('http://example.com/foo/?baz=bap')
-      expect(stub.matches?('GET', 'http://example.com/foo/')).to_not be
-      expect(stub.matches?('GET', 'http://example.com/foo/?baz=bap')).to be
-      expect(stub.matches?('GET', 'http://example.com/foo/bar/?baz=bap')).to_not be
-    end
   end
 
   context "#call (without #and_return)" do

--- a/spec/lib/billy/proxy_request_stub_spec.rb
+++ b/spec/lib/billy/proxy_request_stub_spec.rb
@@ -34,6 +34,19 @@ describe Billy::ProxyRequestStub do
     end
   end
 
+  context "#matches? (with strip_query_params false in config)" do
+    before do
+      Billy.config.strip_query_params = false
+    end
+
+    it 'should match up to and including query strings' do
+      stub = Billy::ProxyRequestStub.new('http://example.com/foo/bar/')
+      expect(stub.matches?('GET', 'http://example.com/foo/')).to_not be
+      expect(stub.matches?('GET', 'http://example.com/foo/bar/')).to be
+      expect(stub.matches?('GET', 'http://example.com/foo/bar/?baz=bap')).to_not be
+    end
+  end
+
   context "#call (without #and_return)" do
     let(:subject) { Billy::ProxyRequestStub.new('url') }
 


### PR DESCRIPTION
Add option in Billy configuration to strip or not to strip query parameters in request stub.
Default value is true, it means that query parameters is striped by default and behavior remain the same as before. But if you like to distinguish different request with query and without query parameters you can do it by setting config value of strip_query_params to false. For example:

Billy.configure do |c|
  c.strip_query_params = false
end