### PR TITLE
Require compatible version of em-http-request

### DIFF
--- a/puffing-billy.gemspec
+++ b/puffing-billy.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "addressable"
   gem.add_runtime_dependency "eventmachine"
   gem.add_runtime_dependency "em-synchrony"
-  gem.add_runtime_dependency "em-http-request"
+  gem.add_runtime_dependency "em-http-request", "~> 1.1.0"
   gem.add_runtime_dependency "eventmachine_httpserver"
   gem.add_runtime_dependency "http_parser.rb", "~> 0.6.0"
   gem.add_runtime_dependency "multi_json"


### PR DESCRIPTION
For some reason my app has version 0.3.0, which is entirely incompatible with billy.