### PR TITLE
Use options to create webkit driver

### DIFF
--- a/lib/billy.rb
+++ b/lib/billy.rb
@@ -42,11 +42,11 @@ module Billy
 
     if defined?(Capybara::Webkit::Driver)
       Capybara.register_driver :webkit_billy do |app|
-        driver = Capybara::Webkit::Driver.new(app)
-        driver.browser.ignore_ssl_errors
-        driver.browser.set_proxy(host: Billy.proxy.host,
-                                 port: Billy.proxy.port)
-        driver
+        options = {
+          :ignore_ssl_errors => false,
+          :proxy => {:host => Billy.proxy.host, :port => Billy.proxy.port}
+        }
+        Capybara::Webkit::Driver.new(app, options)
       end
     end
 

--- a/lib/billy.rb
+++ b/lib/billy.rb
@@ -43,8 +43,8 @@ module Billy
     if defined?(Capybara::Webkit::Driver)
       Capybara.register_driver :webkit_billy do |app|
         options = {
-          :ignore_ssl_errors => false,
-          :proxy => {:host => Billy.proxy.host, :port => Billy.proxy.port}
+          ignore_ssl_errors: false,
+          proxy: {host: Billy.proxy.host, port: Billy.proxy.port}
         }
         Capybara::Webkit::Driver.new(app, options)
       end


### PR DESCRIPTION
 instead of calling deprecated browser method

fixes 

`
[DEPRECATION] Capybara::Webkit::Driver#browser is deprecated.
`