### PR TITLE
Error with method

### DIFF
--- a/lib/billy.rb
+++ b/lib/billy.rb
@@ -42,11 +42,11 @@ module Billy
 
     if defined?(Capybara::Webkit::Driver)
       Capybara.register_driver :webkit_billy do |app|
-        driver = Capybara::Webkit::Driver.new(app)
-        driver.browser.ignore_ssl_errors
-        driver.browser.set_proxy(host: Billy.proxy.host,
-                                 port: Billy.proxy.port)
-        driver
+        options = {
+          :ignore_ssl_errors => false,
+          :proxy => {:host => Billy.proxy.host, :port => Billy.proxy.port}
+        }
+        Capybara::Webkit::Driver.new(app, options)
       end
     end
 

--- a/lib/billy.rb
+++ b/lib/billy.rb
@@ -43,8 +43,8 @@ module Billy
     if defined?(Capybara::Webkit::Driver)
       Capybara.register_driver :webkit_billy do |app|
         options = {
-          :ignore_ssl_errors => false,
-          :proxy => {:host => Billy.proxy.host, :port => Billy.proxy.port}
+          ignore_ssl_errors: false,
+          proxy: {host: Billy.proxy.host, port: Billy.proxy.port}
         }
         Capybara::Webkit::Driver.new(app, options)
       end

--- a/lib/billy/handlers/proxy_handler.rb
+++ b/lib/billy/handlers/proxy_handler.rb
@@ -33,7 +33,7 @@ module Billy
 
           unless allowed_response_code?(response[:status])
             if Billy.config.non_successful_error_level == :error
-              return { error: "Request failed due to response status #{response[:status]} for '#{url}' which was not allowed." }
+              return { error: "#{method} Request failed due to response status #{response[:status]} for '#{url}' which was not allowed." }
             else
               Billy.log(:warn, "puffing-billy: Received response status code #{response[:status]} for '#{url}'")
             end


### PR DESCRIPTION
This is useful to check what request method failed. For example, an OPTIONS or GET/POST.

No specs failed when I made this change.