### PR TITLE
explicit method is required when stubbing out posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ proxy.stub('https://example.com:443/secure/').and_return(:text => 'secrets!!1!')
 proxy.stub('https://example.com/proc/').and_return(Proc.new { |params, headers, body|
   { :text => "Hello, #{params['name'][0]}"}
 })
+
+# Stub out a POST. Don't forget to allow a CORS request and set the method to 'post'
+proxy.stub('http://example.com/api', :method => 'post').and_return(
+  :headers => { 'Access-Control-Allow-Origin' => '*' },
+  :code => 201
+)
 ```
 
 Stubs are reset between tests.  Any requests that are not stubbed will be
@@ -401,4 +407,3 @@ Note that this approach may cause unexpected behavior if your backend sends the 
 
 1. Integration for test frameworks other than rspec.
 2. Show errors from the EventMachine reactor loop in the test output.
-

--- a/examples/post_api.html
+++ b/examples/post_api.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<body>
+  <h1>POST to API</h1>
+  <div id="result"></div>
+  <script type='text/javascript' src='http://code.jquery.com/jquery-1.8.2.min.js'></script>
+  <script type='text/javascript'>
+  $(function () {
+    $.post('http://example.com/api', { foo: 'bar' }).done(function(data) {
+      $('#result').append('Success!');
+    })
+    .fail(function(data) {
+      $('#result').append('Fail!');
+    });
+  })
+  </script>
+</body>

--- a/spec/features/examples/post_api_spec.rb
+++ b/spec/features/examples/post_api_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'jQuery POST API example', type: :feature, js: true do
   before do
-    proxy.stub('http://example.com/api').and_return(
+    proxy.stub('http://example.com/api', method: 'post').and_return(
       headers: { 'Access-Control-Allow-Origin' => '*' },
       code: 201
     )

--- a/spec/features/examples/post_api_spec.rb
+++ b/spec/features/examples/post_api_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'jQuery POST API example', type: :feature, js: true do
+  before do
+    proxy.stub('http://example.com/api').and_return(
+      headers: { 'Access-Control-Allow-Origin' => '*' },
+      code: 201
+    )
+  end
+
+  it 'posts to an API' do
+    visit '/post_api.html'
+    expect(page.find('#result')).to have_content 'Success!'
+  end
+end


### PR DESCRIPTION
The README mentions:

"The cache works with all types of requests and will distinguish between different POST requests to the same URL."

But this isn't correct (as far as I understand it).

So, I created an integration spec that shows the method needs to be set explicitly when stubbing out the proxy. Also, I gave and example in the readme. 

This stumped me for a while. Hopefully, it helps.