### PR TITLE
Change WebKit driver to ignore SSL errors.

### DIFF
--- a/lib/billy.rb
+++ b/lib/billy.rb
@@ -43,7 +43,7 @@ module Billy
     if defined?(Capybara::Webkit::Driver)
       Capybara.register_driver :webkit_billy do |app|
         options = {
-          ignore_ssl_errors: false,
+          ignore_ssl_errors: true,
           proxy: {host: Billy.proxy.host, port: Billy.proxy.port}
         }
         Capybara::Webkit::Driver.new(app, Capybara::Webkit::Configuration.to_hash.merge(options))


### PR DESCRIPTION
I'm not sure why, but the changes in #130 no longer ignores SSL errors for `Capybara::Webkit::Driver`. And as far as I can tell it completely breaks SSL when using the WebKit driver. (Leading to a long and draining debugging process for me yesterday.) You can easily confirm this by adjusting the test suite to run with the WebKit driver instead:

```diff
index 5961b29..a5f2482 100644
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require 'rack'
 require 'logger'
 
 Capybara.app = Rack::Directory.new(File.expand_path('../../examples', __FILE__))
-Capybara.javascript_driver = :poltergeist_billy
+Capybara.javascript_driver = :webkit_billy
 
 Billy.configure do |config|
   config.logger = Logger.new(File.expand_path('../../log/test.log', __FILE__))
```

Would greatly appreciate a bug release in the near future, if possible, to avoid having to workaround this myself manually.

I'd also like to update the test suite in the future to use each supported driver to avoid issues like this.