### PR TITLE
Add documentation and specs for stubbing out options requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ proxy.stub('http://example.com/api', :method => 'post').and_return(
   :headers => { 'Access-Control-Allow-Origin' => '*' },
   :code => 201
 )
+
+# Stub out an OPTIONS request. Set the headers to the values you require.
+proxy.stub(url, :method => :options).and_return(
+  :headers => {
+    'Access-Control-Allow-Methods' => 'GET, PATCH, POST, PUT, OPTIONS',
+    'Access-Control-Allow-Headers' => 'X-Requested-With, X-Prototype-Version, Content-Type',
+    'Access-Control-Allow-Origin'  => '*'
+  },
+  :code => 200
+)
 ```
 
 Stubs are reset between tests.  Any requests that are not stubbed will be

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ proxy.stub('http://example.com/api', :method => 'post').and_return(
 )
 
 # Stub out an OPTIONS request. Set the headers to the values you require.
-proxy.stub(url, :method => :options).and_return(
+proxy.stub('http://example.com/api', :method => :options).and_return(
   :headers => {
     'Access-Control-Allow-Methods' => 'GET, PATCH, POST, PUT, OPTIONS',
     'Access-Control-Allow-Headers' => 'X-Requested-With, X-Prototype-Version, Content-Type',

--- a/examples/preflight_request.html
+++ b/examples/preflight_request.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<body>
+  <h1>Cross Domain Request</h1>
+  <div id="result"></div>
+  <script type='text/javascript' src='http://code.jquery.com/jquery-1.8.2.min.js'></script>
+  <script type='text/javascript'>
+  $(function () {
+    $.ajax(
+      {
+        url: 'http://example.com/api',
+        method: 'GET',
+        contentType: 'json' // setting this forces an OPTIONS request
+      }
+    ).done(function(data) {
+      $('#result').append('Success!');
+    })
+    .fail(function(data) {
+      $('#result').append('Fail!');
+    });
+  })
+  </script>
+</body>

--- a/spec/features/examples/preflight_request_spec.rb
+++ b/spec/features/examples/preflight_request_spec.rb
@@ -11,6 +11,9 @@ describe 'jQuery preflight request example', type: :feature, js: true do
   end
 
   it 'stubs out the OPTIONS request' do
+    visit '/preflight_request.html'
+    expect(page.find('#result')).to have_content 'Fail!'
+
     proxy.stub(url, method: 'options').and_return(
       headers: {
         'Access-Control-Allow-Methods' => 'GET, OPTIONS',

--- a/spec/features/examples/preflight_request_spec.rb
+++ b/spec/features/examples/preflight_request_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'jQuery preflight request example', type: :feature, js: true do
+  let(:url) { 'http://example.com/api' }
+
+  before do
+    proxy.stub(url, method: 'get').and_return(
+      headers: { 'Access-Control-Allow-Origin' => '*' },
+      code: 201
+    )
+  end
+
+  it 'stubs out the OPTIONS request' do
+    proxy.stub(url, method: 'options').and_return(
+      headers: {
+        'Access-Control-Allow-Methods' => 'GET, OPTIONS',
+        'Access-Control-Allow-Headers' => 'Content-Type',
+        'Access-Control-Allow-Origin' => '*'
+      },
+      code: 200
+    )
+
+    visit '/preflight_request.html'
+    expect(page.find('#result')).to have_content 'Success!'
+  end
+end

--- a/spec/lib/billy/proxy_request_stub_spec.rb
+++ b/spec/lib/billy/proxy_request_stub_spec.rb
@@ -12,11 +12,22 @@ describe Billy::ProxyRequestStub do
         .matches?('GET', 'http://example.com')).to be
       expect(Billy::ProxyRequestStub.new('http://example.com', method: :post)
         .matches?('GET', 'http://example.com')).to_not be
+      expect(Billy::ProxyRequestStub.new('http://example.com', method: :options)
+        .matches?('GET', 'http://example.com')).to_not be
 
       expect(Billy::ProxyRequestStub.new('http://example.com', method: :post)
         .matches?('POST', 'http://example.com')).to be
       expect(Billy::ProxyRequestStub.new('http://fooxample.com', method: :post)
         .matches?('POST', 'http://example.com')).to_not be
+        expect(Billy::ProxyRequestStub.new('http://fooxample.com', method: :options)
+          .matches?('POST', 'http://example.com')).to_not be
+
+      expect(Billy::ProxyRequestStub.new('http://example.com', method: :options)
+        .matches?('OPTIONS', 'http://example.com')).to be
+      expect(Billy::ProxyRequestStub.new('http://example.com', method: :options)
+        .matches?('OPTIONS', 'http://zzzzzexample.com')).to_not be
+      expect(Billy::ProxyRequestStub.new('http://example.com', method: :post)
+        .matches?('OPTIONS', 'http://example.com')).to_not be
     end
 
     it 'should match regexps' do

--- a/spec/lib/proxy_spec.rb
+++ b/spec/lib/proxy_spec.rb
@@ -22,6 +22,10 @@ shared_examples_for 'a proxy server' do
   it 'should proxy DELETE requests' do
     expect(http.delete('/echo').body).to eql 'DELETE /echo'
   end
+
+  it 'should proxy OPTIONS requests' do
+    expect(http.run_request(:options, '/echo', nil, nil).body).to eql 'OPTIONS /echo'
+  end
 end
 
 shared_examples_for 'a request stub' do
@@ -59,6 +63,12 @@ shared_examples_for 'a request stub' do
     proxy.stub("#{url}/bam", method: :delete)
       .and_return(text: 'hello, DELETE!')
     expect(http.delete('/bam').body).to eql 'hello, DELETE!'
+  end
+
+  it 'should stub OPTIONS requests' do
+    proxy.stub("#{url}/bim", method: :options)
+      .and_return(text: 'hello, OPTIONS!')
+    expect(http.run_request(:options, '/bim', nil, nil).body).to eql 'hello, OPTIONS!'
   end
 end
 


### PR DESCRIPTION
I was having trouble stubbing out OPTIONS requests. Here are some specs that prove it works.