### PR TITLE
Allow Puffing Billy to run with custom host

### DIFF
--- a/lib/billy/proxy.rb
+++ b/lib/billy/proxy.rb
@@ -47,7 +47,7 @@ module Billy
           Billy.log :error, e.backtrace.join("\n")
         end
 
-        @signature = EM.start_server('127.0.0.1', Billy.config.proxy_port, ProxyConnection) do |p|
+        @signature = EM.start_server(host, Billy.config.proxy_port, ProxyConnection) do |p|
           p.handler = request_handler
           p.cache = @cache if defined?(@cache)
           p.errback do |msg|

--- a/lib/billy/version.rb
+++ b/lib/billy/version.rb
@@ -1,3 +1,3 @@
 module Billy
-  VERSION = '0.6.2'
+  VERSION = '0.6.3'
 end


### PR DESCRIPTION
The server didn't respect the hostname configuration option making it impossible to run Puffing Billy with an external Selenium server.