### PR TITLE
Support distinguishing non-POST requests in cache based on request body

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+before_install:
+  - gem install bundler
 rvm:
   - 1.9.3
   - 2.0.0

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Billy.configure do |c|
   c.proxy_port = 12345 # defaults to random
   c.proxied_request_host = nil
   c.proxied_request_port = 80
+  c.cache_request_body_methods = ['post', 'patch', 'put'] # defaults to ['post']
 end
 ```
 
@@ -270,6 +271,8 @@ continuous integration).
 
 `c.proxied_request_host` and `c.proxied_request_port` are used if an internal proxy
 server is required to access the internet.  Most common in larger companies.
+
+`c.cache_request_body_methods` is used to specify HTTP methods of requests that you would like to cache separately based on the contents of the request body. The default is ['post'].
 
 ### Cache Scopes
 

--- a/lib/billy/cache.rb
+++ b/lib/billy/cache.rb
@@ -80,7 +80,7 @@ module Billy
             end
       body_msg = ''
 
-      if method == 'post' && !ignore_params && !merge_cached_response_key
+      if Billy.config.cache_request_body_methods.include?(method) && !ignore_params && !merge_cached_response_key
         body_formatted = JSONUtils.json?(body.to_s) ? JSONUtils.sort_json(body.to_s) : body.to_s
         body_msg = " with body '#{body_formatted}'"
         key += '_' + Digest::SHA1.hexdigest(body_formatted)

--- a/lib/billy/config.rb
+++ b/lib/billy/config.rb
@@ -10,7 +10,7 @@ module Billy
                   :persist_cache, :ignore_cache_port, :non_successful_cache_disabled, :non_successful_error_level,
                   :non_whitelisted_requests_disabled, :cache_path, :proxy_host, :proxy_port, :proxied_request_inactivity_timeout,
                   :proxied_request_connect_timeout, :dynamic_jsonp, :dynamic_jsonp_keys, :merge_cached_responses_whitelist,
-                  :strip_query_params, :proxied_request_host, :proxied_request_port
+                  :strip_query_params, :proxied_request_host, :proxied_request_port, :cache_request_body_methods
 
     def initialize
       @logger = defined?(Rails) ? Rails.logger : Logger.new(STDOUT)
@@ -39,6 +39,7 @@ module Billy
       @strip_query_params = true
       @proxied_request_host = nil
       @proxied_request_port = 80
+      @cache_request_body_methods = ['post']
     end
   end
 

--- a/lib/billy/handlers/request_handler.rb
+++ b/lib/billy/handlers/request_handler.rb
@@ -21,7 +21,7 @@ module Billy
         end
       end
 
-      body_msg = method == 'post' ? " with body '#{body}'" : ''
+      body_msg = Billy.config.cache_request_body_methods.include?(method) ? " with body '#{body}'" : ''
       { error: "Connection to #{url}#{body_msg} not cached and new http connections are disabled" }
     end
 

--- a/lib/tasks/billy.rake
+++ b/lib/tasks/billy.rake
@@ -75,7 +75,7 @@ namespace :cache do
   def print_cache_details(cache)
     puts "   Scope: #{cache[:scope]}" if cache[:scope]
     puts "     URL: #{cache[:url]}"
-    puts "    Body: #{cache[:body]}" if cache[:method] == 'post'
+    puts "    Body: #{cache[:body]}" if Billy.config.cache_request_body_methods.include?(cache[:method])
     puts " Details: Request method '#{cache[:method]}' returned response status code: '#{cache[:status]}'"
     puts "Filename: #{cache[:filename]}"
     puts "\n\n"

--- a/spec/lib/billy/cache_spec.rb
+++ b/spec/lib/billy/cache_spec.rb
@@ -86,5 +86,33 @@ describe Billy::Cache do
         expect(cache.key('post', analytics_url2, 'body')).to eq identical_cache_key
       end
     end
+
+    context 'with cache_request_body_methods set' do
+      before do
+        allow(Billy.config).to receive(:cache_request_body_methods) {
+          ['patch']
+        }
+      end
+
+      context "for requests with methods specified in cache_request_body_methods" do
+        it "should have a different cache key for requests with different bodies" do
+          key1 = cache.key('patch', "http://example.com", "body1")
+          key2 = cache.key('patch', "http://example.com", "body2")
+          expect(key1).not_to eq key2
+        end
+
+        it "should have the same cache key for requests with the same bodies" do
+          key1 = cache.key('patch', "http://example.com", "body1")
+          key2 = cache.key('patch', "http://example.com", "body1")
+          expect(key1).to eq key2
+        end
+      end
+
+      it "should have the same cache key for request with different bodies if their methods are not included in cache_request_body_methods" do
+          key1 = cache.key('put', "http://example.com", "body1")
+          key2 = cache.key('put', "http://example.com", "body2")
+          expect(key1).to eq key2
+      end
+    end
   end
 end

--- a/spec/lib/billy/handlers/request_handler_spec.rb
+++ b/spec/lib/billy/handlers/request_handler_spec.rb
@@ -97,8 +97,8 @@ describe Billy::RequestHandler do
         expect(subject.handle_request(*args)).to eql(error: 'Connection to url not cached and new http connections are disabled')
       end
 
-      it 'returns an error hash with body message if POST request is not handled' do
-        args[0] = 'post'
+      it 'returns an error hash with body message if request cached based on body is not handled' do
+        args[0] = Billy.config.cache_request_body_methods[0]
         expect(stub_handler).to receive(:handle_request).with(*args)
         expect(cache_handler).to receive(:handle_request).with(*args)
         expect(proxy_handler).to receive(:handle_request).with(*args)


### PR DESCRIPTION
This adds a config option `cache_request_body_methods`, allow you to specify the HTTP methods for which you would like the cache to distinguish between requests with different bodies. Previously, this only applied to POST requests, but PATCH and PUT requests also often have different bodies that it's useful to distinguish between when recording requests and responses in the cache. The default value remains `['post']` so the functionality when the option is not set should not change.

I also added a before_install step to travis.yml to update bundler and fix the `undefined method spec for NilClass` error which was preventing gems from installing sometimes, it looks like this might have been the issue: https://github.com/bundler/bundler/issues/3560.