### PR TITLE
Add optional after_cache_handles_request callback for manipulating cached responses

### DIFF
--- a/lib/billy/config.rb
+++ b/lib/billy/config.rb
@@ -10,7 +10,7 @@ module Billy
                   :persist_cache, :ignore_cache_port, :non_successful_cache_disabled, :non_successful_error_level,
                   :non_whitelisted_requests_disabled, :cache_path, :proxy_host, :proxy_port, :proxied_request_inactivity_timeout,
                   :proxied_request_connect_timeout, :dynamic_jsonp, :dynamic_jsonp_keys, :merge_cached_responses_whitelist,
-                  :strip_query_params, :proxied_request_host, :proxied_request_port, :cache_request_body_methods
+                  :strip_query_params, :proxied_request_host, :proxied_request_port, :cache_request_body_methods, :after_cache_handles_request
 
     def initialize
       @logger = defined?(Rails) ? Rails.logger : Logger.new(STDOUT)
@@ -40,6 +40,7 @@ module Billy
       @proxied_request_host = nil
       @proxied_request_port = 80
       @cache_request_body_methods = ['post']
+      @after_cache_handles_request = nil
     end
   end
 

--- a/lib/billy/handlers/cache_handler.rb
+++ b/lib/billy/handlers/cache_handler.rb
@@ -25,6 +25,11 @@ module Billy
             replace_response_callback(response, url)
           end
 
+          if Billy.config.after_cache_handles_request
+            request = { method: method, url: url, headers: headers, body: body }
+            Billy.config.after_cache_handles_request.call(request, response)
+          end
+
           return response
         end
       end


### PR DESCRIPTION
Adds support for an after_cache_handle_request callback. Useful for things like manipulating CORs headers, result of this issue: https://github.com/oesmith/puffing-billy/issues/139