### PR TITLE
Remove rspec-expectations deprecation warning for README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ you can test it!
 it 'should stub google' do
   proxy.stub('http://www.google.com/').and_return(:text => "I'm not Google!")
   visit 'http://www.google.com/'
-  page.should have_content("I'm not Google!")
+  expect(page).to have_content("I'm not Google!")
 end
 ```
 
@@ -145,7 +145,7 @@ end
 And /^a stub for google$/ do
   proxy.stub('http://www.google.com/').and_return(:text => "I'm not Google!")
   visit 'http://www.google.com/'
-  page.should have_content("I'm not Google!")
+  expect(page).to have_content("I'm not Google!")
 end
 ```
 


### PR DESCRIPTION
"New" expectation syntax gets rid of the following message when running the example:

```shell
DEPRECATION: Using `should` from rspec-expectations' old `:should` syntax without 
explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly 
enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead. 
Called from /cucumber/features/step_definitions/test.rb:8:in `block in <top (required)>'.
```