### PR TITLE
Make stub requests accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,27 @@ RSpec.configure do |config|
 end
 ```
 
+## Stub requests recording
+
+If you want to record requests to stubbed URIs, set the following configuration option:
+
+```ruby
+Billy.configure do |c|
+  c.record_stub_requests = true
+end
+```
+
+Example usage:
+
+```ruby
+it 'should intercept a GET request' do
+  stub = proxy.stub('http://example.com/')
+  visit 'http://example.com/'
+  expect(stub.has_requests?).to be true
+  expect(stub.requests).not_to be_empty
+end
+```
+
 ## Proxy timeouts
 
 By default, the Puffing Billy proxy will use the EventMachine:HttpRequest timeouts of 5 seconds

--- a/examples/intercept_request.html
+++ b/examples/intercept_request.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<body>
+  <h1>Intercept request example</h1>
+  <script type='text/javascript' src='http://code.jquery.com/jquery-1.8.2.min.js'></script>
+  <script type='text/javascript'>
+  $(function () {
+    $.post('http://example.com/', { foo: 'bar' });
+  })
+  </script>
+</body>

--- a/lib/billy/config.rb
+++ b/lib/billy/config.rb
@@ -10,7 +10,7 @@ module Billy
                   :persist_cache, :ignore_cache_port, :non_successful_cache_disabled, :non_successful_error_level,
                   :non_whitelisted_requests_disabled, :cache_path, :proxy_host, :proxy_port, :proxied_request_inactivity_timeout,
                   :proxied_request_connect_timeout, :dynamic_jsonp, :dynamic_jsonp_keys, :merge_cached_responses_whitelist,
-                  :strip_query_params, :proxied_request_host, :proxied_request_port, :cache_request_body_methods
+                  :strip_query_params, :proxied_request_host, :proxied_request_port, :cache_request_body_methods, :record_stub_requests
 
     def initialize
       @logger = defined?(Rails) ? Rails.logger : Logger.new(STDOUT)
@@ -40,6 +40,7 @@ module Billy
       @proxied_request_host = nil
       @proxied_request_port = 80
       @cache_request_body_methods = ['post']
+      @record_stub_requests = false
     end
   end
 

--- a/lib/billy/handlers/stub_handler.rb
+++ b/lib/billy/handlers/stub_handler.rb
@@ -10,7 +10,7 @@ module Billy
         if (stub = find_stub(method, url))
           query_string = Addressable::URI.parse(url).query || ''
           params = CGI.parse(query_string)
-          stub.call(params, headers, body).tap do |response|
+          stub.call(method, url, params, headers, body).tap do |response|
             Billy.log(:info, "puffing-billy: STUB #{method} for '#{url}'")
             return { status: response[0], headers: response[1], content: response[2] }
           end

--- a/spec/features/examples/intercept_request_spec.rb
+++ b/spec/features/examples/intercept_request_spec.rb
@@ -7,14 +7,20 @@ describe 'intercept request example', type: :feature, js: true do
   end
 
   it 'should intercept a GET request directly' do
-    stub = proxy.stub('http://example.com/')
+    stub = proxy.stub('http://example.com/').and_return(
+      headers: { 'Access-Control-Allow-Origin' => '*' },
+      code: 200
+    )
     visit 'http://example.com/'
     expect(stub.has_requests?).to be true
     expect(stub.requests).not_to be_empty
   end
 
   it 'should intercept a POST request through an intermediary page' do
-    stub = proxy.stub('http://example.com/', method: 'post')
+    stub = proxy.stub('http://example.com/', method: 'post').and_return(
+      headers: { 'Access-Control-Allow-Origin' => '*' },
+      code: 200
+    )
     visit '/intercept_request.html'
     Timeout::timeout(5) do
       sleep(0.1) until stub.has_requests?

--- a/spec/features/examples/intercept_request_spec.rb
+++ b/spec/features/examples/intercept_request_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'timeout'
+
+describe 'intercept request example', type: :feature, js: true do
+  before do
+    Billy.config.record_stub_requests = true
+  end
+
+  it 'should intercept a GET request directly' do
+    stub = proxy.stub('http://example.com/')
+    visit 'http://example.com/'
+    expect(stub.has_requests?).to be true
+    expect(stub.requests).not_to be_empty
+  end
+
+  it 'should intercept a POST request through an intermediary page' do
+    stub = proxy.stub('http://example.com/', method: 'post')
+    visit '/intercept_request.html'
+    Timeout::timeout(5) do
+      sleep(0.1) until stub.has_requests?
+    end
+    request = stub.requests.shift
+    expect(request[:body]).to eql 'foo=bar'
+  end
+end


### PR DESCRIPTION
This enables you to inspect (for example) some AJAX requests made by the page that is visited, if the HTML of the page is not changed to reflect a success/error of the request (such as the Facebook api example).