### PR TITLE
Upgrade PhantomJS to 2.0 to fix the Travis build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: ruby
 before_install:
   - gem install bundler
+  - mkdir travis-phantomjs
+  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
+  - export PATH=$PWD/travis-phantomjs:$PATH
+  - phantomjs --version
 rvm:
   - 1.9.3
   - 2.0.0


### PR DESCRIPTION
This solves (supposedly) the random build failures in Travis.

Merge only after reviewing the build process of Travis.