### PR TITLE
Fix response headers by anticipating EventMachine::HttpResponse behavior

### DIFF
--- a/lib/billy/handlers/proxy_handler.rb
+++ b/lib/billy/handlers/proxy_handler.rb
@@ -73,9 +73,9 @@ module Billy
       response = {
         status: req.response_header.status,
         headers: req.response_header.raw,
-        content: req.response.force_encoding('BINARY') }
+        content: req.response.force_encoding('BINARY')
+      }
       response[:headers].merge!('Connection' => 'close')
-      response[:headers].delete('Transfer-Encoding')
       response
     end
 

--- a/lib/billy/proxy_connection.rb
+++ b/lib/billy/proxy_connection.rb
@@ -74,30 +74,25 @@ module Billy
 
     private
 
-    def send_response(response)
-      response = prepare_response_for_evma_httpserver(response)
-
-      res = EM::DelegatedHttpResponse.new(self)
-      res.status = response[:status]
-      res.headers = response[:headers]
-      res.content = response[:content]
-      res.send_response
-    end
-
-    def prepare_response_for_evma_httpserver(response)
+    def prepare_response_headers_for_evma_httpserver(headers)
       # Remove the headers below because they will be added later by evma_httpserver (EventMachine::DelegatedHttpResponse).
       # See https://github.com/eventmachine/evma_httpserver/blob/master/lib/evma_httpserver/response.rb
-      headersToRemove = [
+      headers_to_remove = [
         'transfer-encoding',
         'content-length',
         'content-encoding'
       ]
 
-      response[:headers] = response[:headers].select do |key|
-        !headersToRemove.include?(key.downcase)
-      end
-
-      response
+      headers.delete_if {|key, value| headers_to_remove.include?(key.downcase) }
     end
+
+    def send_response(response)
+      res = EM::DelegatedHttpResponse.new(self)
+      res.status = response[:status]
+      res.headers = prepare_response_headers_for_evma_httpserver(response[:headers])
+      res.content = response[:content]
+      res.send_response
+    end
+    
   end
 end

--- a/lib/billy/proxy_connection.rb
+++ b/lib/billy/proxy_connection.rb
@@ -75,11 +75,29 @@ module Billy
     private
 
     def send_response(response)
+      response = prepare_response_for_evma_httpserver(response)
+
       res = EM::DelegatedHttpResponse.new(self)
       res.status = response[:status]
       res.headers = response[:headers]
       res.content = response[:content]
       res.send_response
+    end
+
+    def prepare_response_for_evma_httpserver(response)
+      # Remove the headers below because they will be added later by evma_httpserver (EventMachine::DelegatedHttpResponse).
+      # See https://github.com/eventmachine/evma_httpserver/blob/master/lib/evma_httpserver/response.rb
+      headersToRemove = [
+        'transfer-encoding',
+        'content-length',
+        'content-encoding'
+      ]
+
+      response[:headers] = response[:headers].select do |key|
+        !headersToRemove.include?(key.downcase)
+      end
+
+      response
     end
   end
 end

--- a/spec/lib/billy/proxy_connection_spec.rb
+++ b/spec/lib/billy/proxy_connection_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Billy::ProxyConnection do
+  context '#prepare_response_headers_for_evma_httpserver' do
+    let(:subject) { Billy::ProxyConnection.new('') }
+    
+    it 'should remove duplicated headers fields' do
+        provided_headers = {
+            'transfer-encoding' => '',
+            'content-length' => '',
+            'content-encoding' => '',
+            'key' => 'value'
+        }
+        expected_headers = { 'key' => 'value' }
+        headers = subject.send(:prepare_response_headers_for_evma_httpserver, provided_headers)
+
+        expect(headers).to eql expected_headers
+    end
+  end
+end


### PR DESCRIPTION
I had an issue where gzipped CSS/JS assets were not accepted by the browser through the Puffing Billy proxy because the headers were tampered with. Since Puffing Billy forces the response content encoding to `binary`, the `Content-Encoding` and `Content-Length` headers should be updated, but they aren't. Later on, in the EventMachine::HttpResponse class, another `Content-Length` header is added which has the right value. Which means at that moment there are two headers which shouldn't be there: the original `Content-Length` header and the `Content-Encoding` header which still points to `gzip`. See https://github.com/eventmachine/evma_httpserver/blob/master/lib/evma_httpserver/response.rb#L194

Tests are fine, but I don't know if it breaks anything else. I would prefer fixing it on the evma_httpserver side, but since that project hasn't been updated in atleast a year... I guess we have to create a workaround here.