### PR TITLE
Keep compatible with em-http-request > 1.1.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GEM
       ffi (~> 1.0, >= 1.0.11)
     cliver (0.3.2)
     coderay (1.1.0)
-    cookiejar (0.3.0)
+    cookiejar (0.3.3)
     cucumber (2.0.2)
       builder (>= 2.1.2)
       cucumber-core (~> 1.2.0)
@@ -40,9 +40,9 @@ GEM
       gherkin (~> 2.12.0)
     daemons (1.2.3)
     diff-lcs (1.2.5)
-    em-http-request (1.1.3)
+    em-http-request (1.1.5)
       addressable (>= 2.3.4)
-      cookiejar (<= 0.3.0)
+      cookiejar (!= 0.3.1)
       em-socksify (>= 0.3)
       eventmachine (>= 1.0.3)
       http_parser.rb (>= 0.6.0)
@@ -50,7 +50,7 @@ GEM
       eventmachine (>= 1.0.0.beta.4)
     em-synchrony (1.0.5)
       eventmachine (>= 1.0.0.beta.1)
-    eventmachine (1.0.8)
+    eventmachine (1.0.9.1)
     eventmachine_httpserver (0.2.1)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
@@ -150,6 +150,3 @@ DEPENDENCIES
   rspec
   selenium-webdriver
   thin
-
-BUNDLED WITH
-   1.11.2

--- a/lib/billy/handlers/proxy_handler.rb
+++ b/lib/billy/handlers/proxy_handler.rb
@@ -54,7 +54,7 @@ module Billy
 
     def build_request_options(url, headers, body)
       headers = Hash[headers.map { |k, v| [k.downcase, v] }]
-      headers.delete('accept-encoding')
+      headers['accept-encoding'] = ''
 
       uri = Addressable::URI.parse(url)
       headers.merge!({'authorization' => [uri.user, uri.password]}) if uri.userinfo


### PR DESCRIPTION
When puffing billy makes a proxy request, it appears to try to force accepting only raw (identity?) encoding and avoid e.g. gzip'd response.

It has been doing this by deleting the accept-encoding header.

em-http-request 1.1.4 has changed its default behaviour to default accept-encoding header if not already set. https://github.com/igrigorik/em-http-request/commit/8c72228d7cf29cba1c72745d6fd0fcc2ab45a8bb

this PR attempts to fix by forcing accept-encoding to empty value instead which effectively explicitly tells em-http-request to not request an encoding
