### PR TITLE
Fix floating scopes

### DIFF
--- a/lib/billy/cache.rb
+++ b/lib/billy/cache.rb
@@ -36,7 +36,7 @@ module Billy
       nil
     end
 
-    def store(method, url, request_headers, body, response_headers, status, content)
+    def store(key, method, url, request_headers, body, response_headers, status, content)
       cached = {
         scope: scope,
         url: format_url(url),
@@ -49,7 +49,6 @@ module Billy
 
       cached.merge!(request_headers: request_headers) if Billy.config.cache_request_headers
 
-      key = key(method, url, body)
       @cache[key] = cached
 
       if Billy.config.persist_cache

--- a/lib/billy/cache.rb
+++ b/lib/billy/cache.rb
@@ -36,9 +36,9 @@ module Billy
       nil
     end
 
-    def store(key, method, url, request_headers, body, response_headers, status, content)
+    def store(key, _scope, method, url, request_headers, body, response_headers, status, content)
       cached = {
-        scope: scope,
+        scope: _scope,
         url: format_url(url),
         body: body,
         status: status,

--- a/lib/billy/handlers/proxy_handler.rb
+++ b/lib/billy/handlers/proxy_handler.rb
@@ -21,6 +21,8 @@ module Billy
                                  port: Billy.config.proxied_request_port }} )
         end
 
+        cache_key = Billy::Cache.instance.key(method.downcase, url, body)
+
         req = EventMachine::HttpRequest.new(url, opts)
         req = req.send(method.downcase, build_request_options(url, headers, body))
 
@@ -40,7 +42,7 @@ module Billy
           end
 
           if cacheable?(url, response[:headers], response[:status])
-            Billy::Cache.instance.store(method.downcase, url, headers, body, response[:headers], response[:status], response[:content])
+            Billy::Cache.instance.store(cache_key, method.downcase, url, headers, body, response[:headers], response[:status], response[:content])
           end
 
           Billy.log(:info, "puffing-billy: PROXY #{method} succeeded for '#{url}'")

--- a/lib/billy/handlers/proxy_handler.rb
+++ b/lib/billy/handlers/proxy_handler.rb
@@ -21,6 +21,7 @@ module Billy
                                  port: Billy.config.proxied_request_port }} )
         end
 
+        cache_scope = Billy::Cache.instance.scope
         cache_key = Billy::Cache.instance.key(method.downcase, url, body)
 
         req = EventMachine::HttpRequest.new(url, opts)
@@ -42,7 +43,17 @@ module Billy
           end
 
           if cacheable?(url, response[:headers], response[:status])
-            Billy::Cache.instance.store(cache_key, method.downcase, url, headers, body, response[:headers], response[:status], response[:content])
+            Billy::Cache.instance.store(
+              cache_key,
+              cache_scope,
+              method.downcase,
+              url,
+              headers,
+              body,
+              response[:headers],
+              response[:status],
+              response[:content]
+            )
           end
 
           Billy.log(:info, "puffing-billy: PROXY #{method} succeeded for '#{url}'")


### PR DESCRIPTION
**Fixes the particular problem with scopes**

_Clean run, cache folder is empty_

1. cache.scope_to 'first'
2. make request, it comes to EM defers queue
3. cache.scope_to 'second'
4. EM processes the request, and caches the response within 'second' scope

_Then the test runs again_

1. cache.scope_to 'first'
2. make request, CacheHandler can't find already cached response within 'first' scope
3. cache.scope_to 'second'
4. EM processes the request and rewrites the cache within 'second' scope