### PR TITLE
Allow to simulate network delays when responding from cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,10 @@ Billy.configure do |c|
 end
 ```
 
+`c.cache_simulates_network_delays` is used to add some delay before cache returns response. When set to `true`, cached requests will wait from configured delay time before responding. This allows to catch various race conditions in asynchronous front-end requests. The default is `false`.
+
+`c.cache_simulates_network_delay_time` is used to configure time (in seconds) to wait until responding from cache. The default is `0.1`.
+
 ### Cache Scopes
 
 If you need to cache different responses to the same HTTP request, you can use

--- a/lib/billy/config.rb
+++ b/lib/billy/config.rb
@@ -10,7 +10,7 @@ module Billy
                   :persist_cache, :ignore_cache_port, :non_successful_cache_disabled, :non_successful_error_level,
                   :non_whitelisted_requests_disabled, :cache_path, :proxy_host, :proxy_port, :proxied_request_inactivity_timeout,
                   :proxied_request_connect_timeout, :dynamic_jsonp, :dynamic_jsonp_keys, :merge_cached_responses_whitelist,
-                  :strip_query_params, :proxied_request_host, :proxied_request_port, :cache_request_body_methods, :after_cache_handles_request,
+                  :strip_query_params, :proxied_request_host, :proxied_request_port, :cache_request_body_methods, :after_cache_handles_request, :cache_simulates_network_delays, :cache_simulates_network_delay_time,
                   :record_stub_requests
 
     def initialize
@@ -42,6 +42,8 @@ module Billy
       @proxied_request_port = 80
       @cache_request_body_methods = ['post']
       @after_cache_handles_request = nil
+      @cache_simulates_network_delays = false
+      @cache_simulates_network_delay_time = 0.1
       @record_stub_requests = false
     end
   end

--- a/lib/billy/handlers/cache_handler.rb
+++ b/lib/billy/handlers/cache_handler.rb
@@ -30,6 +30,10 @@ module Billy
             Billy.config.after_cache_handles_request.call(request, response)
           end
 
+          if Billy.config.cache_simulates_network_delays
+            Kernel.sleep(Billy.config.cache_simulates_network_delay_time)
+          end
+
           return response
         end
       end


### PR DESCRIPTION
We use puffing-billy to record front-end requests to our microservices and later serve them from cache, but sometimes we hit race condition bugs with front-end requests not ordered correctly (e.g. emit event that is not yet listened). These issues are rarely caught during development because all microservices are using localhost so requests are super fast and they are not caught during automated tests because cached responses are instant. However, in production they happen often since there is DNS lookup, real requests, etc.

This PR allows to simulate network delays before responding from cache. It's very simple and delays are not configurable but it has proven to catch/reveal such bugs during automated tests execution.

If this is something you'd like to merge in, I'd be glad to address all your comments and improve it if necessary.

I'm not sure how can I unit test this functionality, so it would be great if you could help me a bit.

P.S. Thank you very much for such a great tool!