### PR TITLE
allow the dynamic jsonp callback name to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,9 @@ using `c.dynamic_jsonp`. This is helpful when JSONP APIs use cache-busting
 parameters. For example, if you want `http://example.com/foo?callback=bar&id=1&cache_bust=12345` and `http://example.com/foo?callback=baz&id=1&cache_bust=98765` to be cache hits for each other, you would set `c.dynamic_jsonp_keys = ['callback', 'cache_bust']` to ignore both params. Note
 that in this example the `id` param would still be considered important.
 
+`c.dynamic_jsonp_callback_name` is used to configure the name of the JSONP callback 
+parameter. The default is `callback`.
+
 `c.path_blacklist = []` is used to always cache specific paths on any hostnames,
 including whitelisted ones.  This is useful if your AUT has routes that get data
 from external services, such as `/api` where the ajax request is a local URL but

--- a/lib/billy/config.rb
+++ b/lib/billy/config.rb
@@ -9,7 +9,7 @@ module Billy
     attr_accessor :logger, :cache, :cache_request_headers, :whitelist, :path_blacklist, :ignore_params,
                   :persist_cache, :ignore_cache_port, :non_successful_cache_disabled, :non_successful_error_level,
                   :non_whitelisted_requests_disabled, :cache_path, :proxy_host, :proxy_port, :proxied_request_inactivity_timeout,
-                  :proxied_request_connect_timeout, :dynamic_jsonp, :dynamic_jsonp_keys, :merge_cached_responses_whitelist,
+                  :proxied_request_connect_timeout, :dynamic_jsonp, :dynamic_jsonp_keys, :dynamic_jsonp_callback_name, :merge_cached_responses_whitelist,
                   :strip_query_params, :proxied_request_host, :proxied_request_port, :cache_request_body_methods, :after_cache_handles_request,
                   :record_stub_requests
 
@@ -28,6 +28,7 @@ module Billy
       @persist_cache = false
       @dynamic_jsonp = false
       @dynamic_jsonp_keys = ['callback']
+      @dynamic_jsonp_callback_name = 'callback'
       @ignore_cache_port = true
       @non_successful_cache_disabled = false
       @non_successful_error_level = :warn

--- a/lib/billy/handlers/cache_handler.rb
+++ b/lib/billy/handlers/cache_handler.rb
@@ -46,8 +46,9 @@ module Billy
       request_uri = Addressable::URI.parse(url)
       if request_uri.query
         params = CGI.parse(request_uri.query)
-        if params['callback'].any? && response[:content].match(/\w+\(/)
-          response[:content].sub!(/\w+\(/, params['callback'].first + '(')
+        callback_name = Billy.config.dynamic_jsonp_callback_name
+        if params[callback_name].any? && response[:content].match(/\w+\(/)
+          response[:content].sub!(/\w+\(/, params[callback_name].first + '(')
         end
       end
     end

--- a/spec/lib/billy/handlers/cache_handler_spec.rb
+++ b/spec/lib/billy/handlers/cache_handler_spec.rb
@@ -2,10 +2,11 @@ require 'spec_helper'
 
 describe Billy::CacheHandler do
   let(:handler) { Billy::CacheHandler.new }
+  let(:request_url) { 'http://example.test:8080/index?some=param&callback=dynamicCallback5678' }
   let(:request) do
     {
       method:   'post',
-      url:      'http://example.test:8080/index?some=param&callback=dynamicCallback5678',
+      url:      request_url,
       headers:  { 'Accept-Encoding'  => 'gzip',
                   'Cache-Control'    => 'no-cache' },
       body:     'Some body'
@@ -112,6 +113,26 @@ describe Billy::CacheHandler do
                                         request[:url],
                                         request[:headers],
                                         request[:body])).to eql(status: 200, headers: { 'Connection' => 'close', 'Access-Control-Allow-Origin' => "*" }, content: 'Some body')
+        end
+      end
+
+      context 'when dynamic_jsonp_callback_name is set' do
+        let(:dynamic_jsonp_callback_name) { 'customCallback' }
+        let(:request_url) { "http://example.test:8080/index?some=param&#{dynamic_jsonp_callback_name}=dynamicCallback5678" }
+
+        before do
+          allow(Billy.config).to receive(:dynamic_jsonp_callback_name) do
+            dynamic_jsonp_callback_name
+          end
+        end
+
+        it 'should call the callback with the specified name' do
+          expect(Billy::Cache.instance).to receive(:cached?).and_return(true)
+          expect(Billy::Cache.instance).to receive(:fetch).and_return(status: 200, headers: { 'Connection' => 'close' }, content: 'dynamicCallback1234({"yolo":"kitten"})')
+          expect(handler.handle_request(request[:method],
+                                        request[:url],
+                                        request[:headers],
+                                        request[:body])).to eql(status: 200, headers: { 'Connection' => 'close' }, content: 'dynamicCallback5678({"yolo":"kitten"})')
         end
       end
     end


### PR DESCRIPTION
We were trying to stub out requests from a third party library which we cannot modify. The library uses JSONP requests with `jsoncallback` as the name of the callback param.

To address this, this PR allows a custom callback name to be passed into the Billy config and keeps the default callback name as `callback`.