### PR TITLE
fix selenium webdriver deprecation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: ruby
 before_install:
   - gem install bundler
-  - mkdir travis-phantomjs
-  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
-  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
-  - export PATH=$PWD/travis-phantomjs:$PATH
   - phantomjs --version
 rvm:
   - 1.9.3

--- a/lib/billy/browsers/capybara.rb
+++ b/lib/billy/browsers/capybara.rb
@@ -55,9 +55,12 @@ module Billy
         end
 
         ::Capybara.register_driver :selenium_chrome_billy do |app|
+          options = Selenium::WebDriver::Chrome::Options.new
+          options.add_argument("--proxy-server=#{Billy.proxy.host}:#{Billy.proxy.port}")
+
           ::Capybara::Selenium::Driver.new(
             app, browser: :chrome,
-            switches: ["--proxy-server=#{Billy.proxy.host}:#{Billy.proxy.port}"]
+            options: options
           )
         end
       end


### PR DESCRIPTION
:args or :switches has been deprecated. The recommended approach is to
use Selenium::WebDriver::Chrome::Options#add_argument instead