### PR TITLE
Prevent eventmachine from installing 1.2.x

### DIFF
--- a/puffing-billy.gemspec
+++ b/puffing-billy.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'watir-webdriver', '0.9.1'
   # addressable 2.5.0 drops support for ruby 1.9.3
   gem.add_runtime_dependency 'addressable', '~> 2.4', '>= 2.4.0'
-  gem.add_runtime_dependency 'eventmachine', '~> 1.0', '>= 1.0.4'
+  gem.add_runtime_dependency 'eventmachine', '~> 1.0.4'
   gem.add_runtime_dependency 'em-synchrony'
   gem.add_runtime_dependency 'em-http-request', '~> 1.1', '>= 1.1.0'
   gem.add_runtime_dependency 'eventmachine_httpserver'


### PR DESCRIPTION
### Description

I'm using Puffing Billy in conjunction with Sauce Connect (and a PAC file when launching Sauce Connect) to run tests in Sauce Labs. After updating Puffing Billy to `0.11.0` recently, I was running into issues with this setup where any request would result in a 502 Bad Gateway error in the browser, because of `connection error: Connection refused` from Sauce Connect. I rolled Puffing Billy back to an earlier version that worked for this configuration to verify that it was an issue caused by the Puffing Billy update.

Using `git bisect` I tracked the root cause to the changes to the gemspec in [this commit](https://github.com/oesmith/puffing-billy/commit/e7839a00b5c86a4641efb51847890cf18715ca59). I was able to work out that the problem only exists when updating `eventmachine` past version `1.0.9.1`.

This change causes `eventmachine` to resolve to `1.0.9.1` and no higher version (next version released is `1.2.0`, latest is `1.2.5` - [eventmachine changelog](https://github.com/eventmachine/eventmachine/blob/master/CHANGELOG.md))

### Notes
There are a number of fixes in versions of `eventmachine` after `1.0.9.1`. Further investigation should be taken into what about versions of `eventmachine` after `1.0.9.1` causes this issue, and how to resolve the root cause of that.

### References
[Commit that caused the issue](https://github.com/oesmith/puffing-billy/commit/e7839a00b5c86a4641efb51847890cf18715ca59)
[eventmachine changelog](https://github.com/eventmachine/eventmachine/blob/master/CHANGELOG.md)

### Risks
Medium
- Verified that my usage of Puffing Billy isn't broken by this change
- Others using Puffing Billy may have different use cases to mine that could be affected