### PR TITLE
Add #unstub method, replace deprecated watir-webdriver with watir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,10 @@ before_script:
   - phantomjs --version
   - bundle --version
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.0
+  - 2.2.0
+  - 2.3.0
+  - 2.4.0
 script: bundle exec rspec spec
+

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ If for any reason you'd need to reset stubs manually you can do it in two ways:
 
 ```ruby
 # reset a single stub
-proxy.unstub 'http://example.com/get/'
-proxy.unstub 'http://example.com/update/', :method => :post
+example_stub = proxy.stub('http://example.com/text/').and_return(:text => 'Foobar')
+proxy.unstub example_stub
 
 # reset all stubs
 proxy.reset

--- a/README.md
+++ b/README.md
@@ -128,6 +128,17 @@ proxy.stub('http://example.com/api', :method => :options).and_return(
 Stubs are reset between tests.  Any requests that are not stubbed will be
 proxied to the remote server.
 
+If for any reason you'd need to reset stubs manually you can do it in two ways:
+
+```ruby
+# reset a single stub
+proxy.unstub 'http://example.com/get/'
+proxy.unstub 'http://example.com/update/', :method => :post
+
+# reset all stubs
+proxy.reset
+```
+
 ## Cucumber Usage
 
 An example feature:

--- a/lib/billy/browsers/watir.rb
+++ b/lib/billy/browsers/watir.rb
@@ -1,5 +1,5 @@
 require 'billy'
-require 'watir-webdriver'
+require 'watir'
 
 module Billy
   module Browsers
@@ -25,8 +25,9 @@ module Billy
       end
 
       def configure_phantomjs(args)
-        args[:args] ||= []
-        args[:args] += %W[--proxy=#{Billy.proxy.host}:#{Billy.proxy.port}]
+        args[:driver_opts] ||= {}
+        args[:driver_opts][:args] ||= []
+        args[:driver_opts][:args] += %W[--proxy=#{Billy.proxy.host}:#{Billy.proxy.port}]
         args
       end
 

--- a/lib/billy/handlers/request_handler.rb
+++ b/lib/billy/handlers/request_handler.rb
@@ -5,7 +5,7 @@ module Billy
     extend Forwardable
     include Handler
 
-    def_delegators :stub_handler, :stub
+    def_delegators :stub_handler, :stub, :unstub
 
     def handlers
       @handlers ||= { stubs: StubHandler.new,

--- a/lib/billy/handlers/stub_handler.rb
+++ b/lib/billy/handlers/stub_handler.rb
@@ -34,9 +34,8 @@ module Billy
       new_stub
     end
 
-    def unstub(url, options = {:method => :get})
-      method = options[:method].to_s.upcase
-      stubs.delete_if { |stub| stub.matches?(method, url) }
+    def unstub(stub)
+      stubs.delete stub
     end
 
     private

--- a/lib/billy/handlers/stub_handler.rb
+++ b/lib/billy/handlers/stub_handler.rb
@@ -34,6 +34,11 @@ module Billy
       new_stub
     end
 
+    def unstub(url, options = {:method => :get})
+      method = options[:method].to_s.upcase
+      stubs.delete_if { |stub| stub.matches?(method, url) }
+    end
+
     private
 
     attr_writer :stubs

--- a/lib/billy/proxy.rb
+++ b/lib/billy/proxy.rb
@@ -6,7 +6,7 @@ module Billy
     extend Forwardable
     attr_reader :request_handler
 
-    def_delegators :request_handler, :stub, :reset, :reset_cache, :restore_cache, :handle_request
+    def_delegators :request_handler, :stub, :unstub, :reset, :reset_cache, :restore_cache, :handle_request
 
     def initialize
       @request_handler = Billy::RequestHandler.new

--- a/puffing-billy.gemspec
+++ b/puffing-billy.gemspec
@@ -28,10 +28,9 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rb-inotify'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'cucumber'
-  gem.add_development_dependency 'watir-webdriver', '0.9.1'
-  # addressable 2.5.0 drops support for ruby 1.9.3
-  gem.add_runtime_dependency 'addressable', '~> 2.4', '>= 2.4.0'
-  gem.add_runtime_dependency 'eventmachine', '1.2.0.1'
+  gem.add_development_dependency 'watir', '~> 6.10.0'
+  gem.add_runtime_dependency 'addressable', '~> 2.5'
+  gem.add_runtime_dependency 'eventmachine', '~> 1.0.4'
   gem.add_runtime_dependency 'em-synchrony'
   gem.add_runtime_dependency 'em-http-request', '~> 1.1', '>= 1.1.0'
   gem.add_runtime_dependency 'eventmachine_httpserver'

--- a/spec/lib/billy/handlers/stub_handler_spec.rb
+++ b/spec/lib/billy/handlers/stub_handler_spec.rb
@@ -64,12 +64,10 @@ describe Billy::StubHandler do
   end
 
   describe '#unstub' do
-    before do
-      handler.stub('http://example.post/', method: :post)
-      handler.stub('http://example.get/')
-    end
+    let!(:get_stub) { handler.stub('http://example.get/') }
+    let!(:post_stub) { handler.stub('http://example.post/', method: :post) }
 
-    it 'removes the stub a one GET request' do
+    it 'removes a single stub' do
       expect(handler.handles_request?('GET',
                                       'http://example.get/',
                                       request[:headers],
@@ -79,7 +77,7 @@ describe Billy::StubHandler do
                                       request[:headers],
                                       request[:body])).to be true
 
-      handler.unstub 'http://example.get/'
+      handler.unstub get_stub
 
       expect(handler.handles_request?('GET',
                                       'http://example.get/',
@@ -89,28 +87,6 @@ describe Billy::StubHandler do
                                       'http://example.post/',
                                       request[:headers],
                                       request[:body])).to be true
-    end
-
-    it 'removes the stub for a POST request' do
-      expect(handler.handles_request?('GET',
-                                      'http://example.get/',
-                                      request[:headers],
-                                      request[:body])).to be true
-      expect(handler.handles_request?('POST',
-                                      'http://example.post/',
-                                      request[:headers],
-                                      request[:body])).to be true
-
-      handler.unstub 'http://example.post/', :method => :post
-
-      expect(handler.handles_request?('GET',
-                                      'http://example.get/',
-                                      request[:headers],
-                                      request[:body])).to be true
-      expect(handler.handles_request?('POST',
-                                      'http://example.post/',
-                                      request[:headers],
-                                      request[:body])).to be false
     end
 
     it 'does not raise errors for not existing stub' do

--- a/spec/lib/billy/handlers/stub_handler_spec.rb
+++ b/spec/lib/billy/handlers/stub_handler_spec.rb
@@ -63,6 +63,61 @@ describe Billy::StubHandler do
     end
   end
 
+  describe '#unstub' do
+    before do
+      handler.stub('http://example.post/', method: :post)
+      handler.stub('http://example.get/')
+    end
+
+    it 'removes the stub a one GET request' do
+      expect(handler.handles_request?('GET',
+                                      'http://example.get/',
+                                      request[:headers],
+                                      request[:body])).to be true
+      expect(handler.handles_request?('POST',
+                                      'http://example.post/',
+                                      request[:headers],
+                                      request[:body])).to be true
+
+      handler.unstub 'http://example.get/'
+
+      expect(handler.handles_request?('GET',
+                                      'http://example.get/',
+                                      request[:headers],
+                                      request[:body])).to be false
+      expect(handler.handles_request?('POST',
+                                      'http://example.post/',
+                                      request[:headers],
+                                      request[:body])).to be true
+    end
+
+    it 'removes the stub for a POST request' do
+      expect(handler.handles_request?('GET',
+                                      'http://example.get/',
+                                      request[:headers],
+                                      request[:body])).to be true
+      expect(handler.handles_request?('POST',
+                                      'http://example.post/',
+                                      request[:headers],
+                                      request[:body])).to be true
+
+      handler.unstub 'http://example.post/', :method => :post
+
+      expect(handler.handles_request?('GET',
+                                      'http://example.get/',
+                                      request[:headers],
+                                      request[:body])).to be true
+      expect(handler.handles_request?('POST',
+                                      'http://example.post/',
+                                      request[:headers],
+                                      request[:body])).to be false
+    end
+
+    it 'does not raise errors for not existing stub' do
+      expect { handler.unstub 'http://example.option/' }.not_to raise_error
+    end
+  end
+
   it '#stubs requests' do
     handler.stub('http://example.test:8080/index')
     expect(handler.handles_request?('GET',


### PR DESCRIPTION
In some test cases, it is required to dynamically decide which requests should be stubbed, and which not. Using `proxy.reset` is not the best way to it since it provides no control over which stubs are to be removed.

This PR adds a new method: `proxy.unstub`, which acts as a reverse to `proxy.stub`, and removes only a single stub.

See `spec/lib/billy/handlers/stub_handler_spec.rb:66` for examples.

Additionally, this PR removes dependency `watir-webdriver`. That gem was outdated, deprecated and in fact already has already been removed from GitHub. It is now a part of `watir` gem, and this one has been added instead.

`watir-webdriver` was throwing a ton of warnings (Fixnum) and an exception on just `require 'watir-webdriver'` making work on this change impossible.