### PR TITLE
Bump eventmachine version to support loading HTTP/2 resources

### DIFF
--- a/puffing-billy.gemspec
+++ b/puffing-billy.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'watir-webdriver', '0.9.1'
   # addressable 2.5.0 drops support for ruby 1.9.3
   gem.add_runtime_dependency 'addressable', '~> 2.4', '>= 2.4.0'
-  gem.add_runtime_dependency 'eventmachine', '~> 1.0.4'
+  gem.add_runtime_dependency 'eventmachine', '1.2.0.1'
   gem.add_runtime_dependency 'em-synchrony'
   gem.add_runtime_dependency 'em-http-request', '~> 1.1', '>= 1.1.0'
   gem.add_runtime_dependency 'eventmachine_httpserver'


### PR DESCRIPTION
### Description
An unintended side-affect of my last PR #206 was that PROXY requests to HTTP/2 resources traversing Puffing Billy would fail. I found that updating `eventmachine` to a version >= 1.2 would fix that issue.

As an extra note: the 502 Bad Gateway responses I was seeing in #206 were actually an issue with configuring Puffing Billy. I did some digging with Wireshark and found that the requests were all getting through the Sauce Connect tunnel, but Puffing Billy was actually rejecting them. I had set the `proxy_port` to a specific number, but left `proxy_host` as its default of `localhost`. What I needed to do was specifically set that to `127.0.0.1` to force it to use IPv4 - problem solved.

### References
#206 

### Risks
Medium
- Gem bump may have unintended side-effects