### PR TITLE
Check if cache_file is a symlink, and if so, return the linked file

### DIFF
--- a/lib/billy/cache.rb
+++ b/lib/billy/cache.rb
@@ -118,7 +118,13 @@ module Billy
     end
 
     def cache_file(key)
-      File.join(Billy.config.cache_path, "#{key}.yml")
+      file = File.join(Billy.config.cache_path, "#{key}.yml")
+
+      if File.symlink? file
+        file = File.readlink file
+      end
+
+      file
     end
 
     def scope_to(new_scope = nil)


### PR DESCRIPTION
This allows `puffing_billy` to follow symlinks.

This is helpful for infrastructures that support certain mocks being shared.