### PR TITLE
WIP: Allow use of shared mocks

### DIFF
--- a/lib/billy/browsers/capybara.rb
+++ b/lib/billy/browsers/capybara.rb
@@ -57,6 +57,7 @@ module Billy
         ::Capybara.register_driver :selenium_chrome_billy do |app|
           options = Selenium::WebDriver::Chrome::Options.new
           options.add_argument("--proxy-server=#{Billy.proxy.host}:#{Billy.proxy.port}")
+          options.add_argument("--proxy-bypass-list=localhost")
 
           ::Capybara::Selenium::Driver.new(
             app, browser: :chrome,

--- a/lib/billy/cache.rb
+++ b/lib/billy/cache.rb
@@ -51,8 +51,13 @@ module Billy
 
       @cache[key] = cached
 
+
       if Billy.config.persist_cache
-        Dir.mkdir(Billy.config.cache_path) unless File.exist?(Billy.config.cache_path)
+        if Billy.config.use_shared_mocks
+          Dir.mkdir_p(Billy.config.shared_mock_path)
+        end
+
+        Dir.mkdir_p(Billy.config.cache_path)
 
         begin
           File.open(cache_file(key), 'w') do |f|
@@ -118,7 +123,18 @@ module Billy
     end
 
     def cache_file(key)
-      file = File.join(Billy.config.cache_path, "#{key}.yml")
+      # set the path to the default path
+      path = Billy.config.cache_path
+
+      # if shared mocks is on and the key matches the shared mock glob
+      if Billy.config.use_shared_mocks
+        if Billy.config.shared_mock_key_match.match(key)
+          # set the path to the shared path
+          path = Billy.config.shared_mock_path
+        end
+      end
+
+      file = File.join(path, "#{key}.yml")
 
       if File.symlink? file
         file = File.readlink file

--- a/lib/billy/cache.rb
+++ b/lib/billy/cache.rb
@@ -54,10 +54,10 @@ module Billy
 
       if Billy.config.persist_cache
         if Billy.config.use_shared_mocks
-          Dir.mkdir_p(Billy.config.shared_mock_path)
+          FileUtils.mkdir_p(Billy.config.shared_mock_path)
         end
 
-        Dir.mkdir_p(Billy.config.cache_path)
+        FileUtils.mkdir_p(Billy.config.cache_path)
 
         begin
           File.open(cache_file(key), 'w') do |f|

--- a/lib/billy/config.rb
+++ b/lib/billy/config.rb
@@ -6,12 +6,19 @@ module Billy
     DEFAULT_WHITELIST = ['127.0.0.1', 'localhost']
     RANDOM_AVAILABLE_PORT = 0 # https://github.com/eventmachine/eventmachine/wiki/FAQ#wiki-can-i-start-a-server-on-a-random-available-port
 
-    attr_accessor :logger, :cache, :cache_request_headers, :whitelist, :path_blacklist, :ignore_params, :allow_params,
-                  :persist_cache, :ignore_cache_port, :non_successful_cache_disabled, :non_successful_error_level,
-                  :non_whitelisted_requests_disabled, :cache_path, :certs_path, :proxy_host, :proxy_port, :proxied_request_inactivity_timeout,
-                  :proxied_request_connect_timeout, :dynamic_jsonp, :dynamic_jsonp_keys, :dynamic_jsonp_callback_name, :merge_cached_responses_whitelist,
-                  :strip_query_params, :proxied_request_host, :proxied_request_port, :cache_request_body_methods, :after_cache_handles_request,
-                  :cache_simulates_network_delays, :cache_simulates_network_delay_time, :record_stub_requests, :use_ignore_params
+    attr_accessor :logger, :cache, :cache_request_headers, :whitelist,
+      :path_blacklist, :ignore_params, :allow_params, :persist_cache,
+      :ignore_cache_port, :non_successful_cache_disabled,
+      :non_successful_error_level, :non_whitelisted_requests_disabled,
+      :cache_path, :certs_path, :proxy_host, :proxy_port,
+      :proxied_request_inactivity_timeout, :proxied_request_connect_timeout,
+      :dynamic_jsonp, :dynamic_jsonp_keys, :dynamic_jsonp_callback_name,
+      :merge_cached_responses_whitelist, :strip_query_params,
+      :proxied_request_host, :proxied_request_port, :cache_request_body_methods,
+      :after_cache_handles_request, :cache_simulates_network_delays,
+      :cache_simulates_network_delay_time, :record_stub_requests,
+      :use_ignore_params, :use_shared_mocks, :shared_mock_path,
+      :shared_mock_key_match
 
     def initialize
       @logger = defined?(Rails) ? Rails.logger : Logger.new(STDOUT)
@@ -49,6 +56,9 @@ module Billy
       @cache_simulates_network_delay_time = 0.1
       @record_stub_requests = false
       @use_ignore_params = true
+      @use_shared_mocks = false
+      @shared_mock_path = File.join(Dir.tmpdir, 'puffing-billy', 'shared')
+      @shared_mock_key_match = //
     end
   end
 


### PR DESCRIPTION
This is great to have when, i.e. you are putting different tests in different directories, but want some mocks to come from a single directory