### PR TITLE
Expose stub instances via puffing billy

### DIFF
--- a/lib/billy/handlers/request_handler.rb
+++ b/lib/billy/handlers/request_handler.rb
@@ -28,11 +28,13 @@ module Billy
     end
 
     def handles_request?(method, url, headers, body)
-      [:stubs, :cache, :proxy].each do |key|
-        return true if handlers[key].handles_request?(method, url, headers, body)
+      [:stubs, :cache, :proxy].any? do |key|
+        handlers[key].handles_request?(method, url, headers, body)
       end
+    end
 
-      false
+    def stubs
+      stub_handler.stubs
     end
 
     def reset
@@ -40,7 +42,7 @@ module Billy
     end
 
     def reset_stubs
-      handlers[:stubs].reset
+      stub_handler.reset
     end
 
     def reset_cache

--- a/lib/billy/handlers/stub_handler.rb
+++ b/lib/billy/handlers/stub_handler.rb
@@ -38,13 +38,13 @@ module Billy
       stubs.delete stub
     end
 
-    private
-
-    attr_writer :stubs
-
     def stubs
       @stubs ||= []
     end
+
+    private
+
+    attr_writer :stubs
 
     def find_stub(method, url)
       stubs.find { |stub| stub.matches?(method, url) }

--- a/lib/billy/proxy.rb
+++ b/lib/billy/proxy.rb
@@ -6,7 +6,7 @@ module Billy
     extend Forwardable
     attr_reader :request_handler
 
-    def_delegators :request_handler, :stub, :unstub, :reset, :reset_cache, :restore_cache, :handle_request
+    def_delegators :request_handler, :stub, :stubs, :unstub, :reset, :reset_cache, :restore_cache, :handle_request
 
     def initialize
       @request_handler = Billy::RequestHandler.new

--- a/spec/lib/billy/handlers/request_handler_spec.rb
+++ b/spec/lib/billy/handlers/request_handler_spec.rb
@@ -121,6 +121,13 @@ describe Billy::RequestHandler do
       end
     end
 
+    describe '#stubs' do
+      it 'delegates to the stub_handler' do
+        expect(stub_handler).to receive(:stubs)
+        subject.stubs
+      end
+    end
+
     describe '#stub' do
       it 'delegates to the stub_handler' do
         expect(stub_handler).to receive(:stub).with('some args')

--- a/spec/lib/billy/handlers/stub_handler_spec.rb
+++ b/spec/lib/billy/handlers/stub_handler_spec.rb
@@ -44,18 +44,18 @@ describe Billy::StubHandler do
   end
 
   describe '#reset' do
-    before do
+    it 'resets the stubs' do
       # Can't use request params when creating the stub.
       # See https://github.com/oesmith/puffing-billy/issues/21
-      handler.stub('http://example.test:8080/index')
-    end
+      stub = handler.stub('http://example.test:8080/index')
 
-    it 'resets the stubs' do
+      expect(handler.stubs).to eql([stub])
       expect(handler.handles_request?('GET',
                                       request[:url],
                                       request[:headers],
                                       request[:body])).to be true
       handler.reset
+      expect(handler.stubs).to be_empty
       expect(handler.handles_request?('GET',
                                       request[:url],
                                       request[:headers],
@@ -100,5 +100,18 @@ describe Billy::StubHandler do
                                     request[:url],
                                     request[:headers],
                                     request[:body])).to be true
+  end
+
+  describe '#stubs' do
+    it 'is empty by default' do
+      expect(handler.stubs).to be_empty
+    end
+
+    it 'keeps track of created stubs' do
+      stub1 = handler.stub('http://example.test:8080/index')
+      stub2 = handler.stub('http://example.test:8080/index')
+
+      expect(handler.stubs).to eql([stub2, stub1])
+    end
   end
 end

--- a/spec/lib/proxy_spec.rb
+++ b/spec/lib/proxy_spec.rb
@@ -69,6 +69,14 @@ shared_examples_for 'a request stub' do
       .and_return(text: 'hello, OPTIONS!')
     expect(http.run_request(:options, '/bim', nil, nil).body).to eql 'hello, OPTIONS!'
   end
+
+  it 'should expose the currently registered stubs' do
+    stub1 = proxy.stub("#{url}/foo", method: :options)
+      .and_return(text: 'hello, OPTIONS!')
+    stub2 = proxy.stub("#{url}/bar", method: :options)
+              .and_return(text: 'hello, OPTIONS!')
+    expect(proxy.stubs).to eql([stub2, stub1])
+  end
 end
 
 shared_examples_for 'a cache' do


### PR DESCRIPTION
It would be nice to expose the currently registered stubbed instances via puffing billy.
This will allow for developers to learn which stubs were not correctly called, or are dead:

```ruby
Billy.configure do |c|
  c.record_stub_requests = true
end

config.after(:example, type: :feature) do
  unused_stubs = proxy.stubs.select { |stub| stub.requests.empty? }
  expect(unused_proxy_stubs).to be_empty, "expected all stubs to be used, however no requests were received for #{unused_proxy_stubs}"
end
```