### PR TITLE
Catch unhandled request handler errors

### DIFF
--- a/lib/billy/handlers/request_handler.rb
+++ b/lib/billy/handlers/request_handler.rb
@@ -23,6 +23,8 @@ module Billy
 
       body_msg = Billy.config.cache_request_body_methods.include?(method) ? " with body '#{body}'" : ''
       { error: "Connection to #{url}#{body_msg} not cached and new http connections are disabled" }
+    rescue => error
+      { error: error.message }
     end
 
     def handles_request?(method, url, headers, body)

--- a/spec/lib/billy/handlers/request_handler_spec.rb
+++ b/spec/lib/billy/handlers/request_handler_spec.rb
@@ -104,6 +104,21 @@ describe Billy::RequestHandler do
         expect(proxy_handler).to receive(:handle_request).with(*args)
         expect(subject.handle_request(*args)).to eql(error: "Connection to url with body 'body' not cached and new http connections are disabled")
       end
+
+      it 'returns an error hash on unhandled exceptions' do
+        # Allow handling requests initially
+        allow(stub_handler).to receive(:handle_request)
+        allow(cache_handler).to receive(:handle_request)
+
+        allow(proxy_handler).to receive(:handle_request).and_raise("Any Proxy Error")
+        expect(subject.handle_request(*args)).to eql(error: "Any Proxy Error")
+
+        allow(cache_handler).to receive(:handle_request).and_raise("Any Cache Error")
+        expect(subject.handle_request(*args)).to eql(error: "Any Cache Error")
+
+        allow(stub_handler).to receive(:handle_request).and_raise("Any Stub Error")
+        expect(subject.handle_request(*args)).to eql(error: "Any Stub Error")
+      end
     end
 
     describe '#stub' do


### PR DESCRIPTION
This fixes an issue where when an underlying error happens, say someone is using VCR for client side stubs and it raises an error, the web process hangs due to the proxy crashing. This catches any unhandled standard error and returns it as part of the error hash from the request. This will result in the error message being written to the log and allowing the proxy to continue running.