### PR TITLE
Fix Selenium::WebDriver::Firefox deprecation warning

### DIFF
--- a/lib/billy/browsers/capybara.rb
+++ b/lib/billy/browsers/capybara.rb
@@ -51,7 +51,8 @@ module Billy
           profile.proxy = Selenium::WebDriver::Proxy.new(
             http: "#{Billy.proxy.host}:#{Billy.proxy.port}",
             ssl: "#{Billy.proxy.host}:#{Billy.proxy.port}")
-          ::Capybara::Selenium::Driver.new(app, profile: profile)
+          options = Selenium::WebDriver::Firefox::Options.new(profile: profile)
+          ::Capybara::Selenium::Driver.new(app, options: options)
         end
 
         ::Capybara.register_driver :selenium_chrome_billy do |app|


### PR DESCRIPTION
Passing a :profile option directly to ::Capybara::Selenium::Driver.new is deprecated.
A custom Firefox profile should be assigned to a Selenium::WebDriver::Firefox::Options
instance with #profile=. This options instance is then passed to ::Capybara::Selenium::Driver.new.

See the comment on #profile= here:
https://github.com/SeleniumHQ/selenium/blob/2300e36377b8609938c94f1211aff117e2a483a6/rb/lib/selenium/webdriver/firefox/options.rb#L109