### PR TITLE
Allow request/response interception on stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,25 @@ proxy.stub('https://example.com:443/secure/').and_return(:text => 'secrets!!1!')
 #   params:  Query string parameters hash, CGI::escape-style
 #   headers: Headers hash
 #   body:    Request body string
-#
-proxy.stub('https://example.com/proc/').and_return(Proc.new { |params, headers, body|
-  { :text => "Hello, #{params['name'][0]}"}
+#   url:     The actual URL which was requested
+#   method:  The HTTP verb which was requested
+proxy.stub('https://example.com/proc/').and_return(Proc.new { |params, headers, body, url, method|
+  {
+    :code => 200,
+    :text => "Hello, #{params['name'][0]}"
+  }
+})
+
+# You can also use Puffing Billy to intercept requests and responses. Just pass
+# a Proc and use the pass_request method. You can manipulate the request
+# (headers, URL, HTTP method, etc) and also the response from the upstream
+# server.
+proxy.stub('http://example.com/').and_return(Proc.new { |*args|
+  response = pass_request(*args)
+  response[:headers]['Content-Type'] = 'text/plain'
+  response[:body] = 'Hello World!'
+  response[:code] = 200
+  response
 })
 
 # Stub out a POST. Don't forget to allow a CORS request and set the method to 'post'

--- a/lib/billy/proxy_request_stub.rb
+++ b/lib/billy/proxy_request_stub.rb
@@ -21,7 +21,7 @@ module Billy
       push_request(method, url, params, headers, body)
 
       if @response.respond_to?(:call)
-        res = @response.call(params, headers, body)
+        res = instance_exec(params, headers, body, url, method, &@response)
       else
         res = @response
       end
@@ -69,6 +69,16 @@ module Billy
           Billy.config.strip_query_params ? (url.split('?')[0] == @url) : (url == @url)
         end
       end
+    end
+
+    def pass_request(params, headers, body, url, method)
+      handler = Billy.proxy.request_handler.handlers[:proxy]
+      response = handler.handle_request(method, url, headers, body)
+      {
+        code: response[:status],
+        body: response[:content],
+        headers: response[:headers]
+      }
     end
 
     private


### PR DESCRIPTION
**- What is it good for?**

This update ships the possibility to intercept requests and responses on the proxy stub method. This is quite handy when you want to modify ugly client requests or just want to modify the response body on certain requests. In the test suite where this feature was implemented, we wanted to intercept responses with a content disposition header and save their content to file. (aka file download) This is required due to the [some bugs on Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=819220) atm. (Cant save PDF files on headless, crash on new tabs of PDF files on non-headless)

**- What I did**

I added a new `pass_request` method to the `ProxyRequestStub` class which makes use of the existing functionality of the proxy handler. Furthermore, I switched the proc execution mechanism from `Proc#call` to `Object#instance_exec` to allow a lean syntax on the given Proc. See the examples in the readme. I also added the requested URL and its HTTP method to the list of arguments of the `and_return` callable. This was proved on the corresponding test. A new test case was added to prove the `pass_request` mechanism. Unfortunately eventmachine weeps about: `(eval):8:in `resume': double resume (FiberError)` on the test case. I have to dig into this, or if anybody knows why/how to fix this - tell me. :)

**- A picture of a cute animal (not mandatory but encouraged)**

![images 1](https://user-images.githubusercontent.com/2496275/37046812-84274b1c-2169-11e8-90df-f7289339e443.jpeg)