### PR TITLE
Allow customization of Options & Profiles for Capybara proxy drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ profile = Selenium::WebDriver::Firefox::Profile.load(
 )
 
 # Register the driver using the provided profile
-driver = Billy::Browsers::Capybara.register_selenium_firefox(profile)
+Billy::Browsers::Capybara.register_selenium_firefox(profile)
 
 # Use the profile as the javascript driver
-Capybara.javascript_driver = driver
+Capybara.javascript_driver = :selenium_billy
 ```
 
 ### Setup for Watir

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ If you need to configure additional settings on the driver -- for example, to
 simulate browsing as an anonymous user -- you can manually register a driver
 and pass it a profile object.
 
+In your `rails_helper.rb`:
+
 ```ruby
 require 'capybara/rspec'
 require 'billy/browsers/capybara'

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ require 'billy/init/rspec'
 
 # Get the anonymous profile
 profile = Selenium::WebDriver::Firefox::Profile.load(
-  Selenium::WebDriver::Firefox::Profile.ANONYMOUS_PROFILE_NAME
+  Selenium::WebDriver::Firefox::Profile::ANONYMOUS_PROFILE_NAME
 )
 
 # Register the driver using the provided profile

--- a/README.md
+++ b/README.md
@@ -64,6 +64,28 @@ Capybara.javascript_driver = :selenium_billy # Uses Firefox
 `:webkit_billy` for headless specs when using puffing-billy for other local rack apps.
 See [this phantomjs issue](https://github.com/ariya/phantomjs/issues/11342) for any updates.
 
+#### Advanced setup
+If you need to configure additional settings on the driver -- for example, to
+simulate browsing as an anonymous user -- you can manually register a driver
+and pass it a profile object.
+
+```ruby
+require 'capybara/rspec'
+require 'billy/browsers/capybara'
+require 'billy/init/rspec'
+
+# Get the anonymous profile
+profile = Selenium::WebDriver::Firefox::Profile.load(
+  Selenium::WebDriver::Firefox::Profile.ANONYMOUS_PROFILE_NAME
+)
+
+# Register the driver using the provided profile
+driver = Billy::Browsers::Capybara.register_selenium_firefox(profile)
+
+# Use the profile as the javascript driver
+Capybara.javascript_driver = driver
+```
+
 ### Setup for Watir
 
 In your `rails_helper.rb`:

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ See [this phantomjs issue](https://github.com/ariya/phantomjs/issues/11342) for 
 
 #### Advanced setup
 If you need to configure additional settings on the driver -- for example, to
-simulate browsing as an anonymous user -- you can manually register a driver
-and pass it a profile object.
+simulate browsing at different screen sizes -- you can manually register a driver
+and pass it an options object.
 
 In your `rails_helper.rb`:
 
@@ -76,16 +76,12 @@ require 'capybara/rspec'
 require 'billy/browsers/capybara'
 require 'billy/init/rspec'
 
-# Get the anonymous profile
-profile = Selenium::WebDriver::Firefox::Profile.load(
-  Selenium::WebDriver::Firefox::Profile::ANONYMOUS_PROFILE_NAME
-)
-
 # Register the driver using the provided profile
-Billy::Browsers::Capybara.register_selenium_firefox(profile)
+# Change the screen size to exercise desktop/mobile logic
+Billy::Browsers::Capybara.register_poltergeist_driver(screen_size: [1920, 1080])
 
 # Use the profile as the javascript driver
-Capybara.javascript_driver = :selenium_billy
+Capybara.javascript_driver = :poltergeist_billy
 ```
 
 ### Setup for Watir

--- a/lib/billy/browsers/capybara.rb
+++ b/lib/billy/browsers/capybara.rb
@@ -59,7 +59,7 @@ module Billy
       # Register firefox with a proxy
       # @param profile [Capybara::WebDriver::Firefox::Profile] the profile
       # to pass to the driver
-      def self.register_selenium_firefox(profile)
+      def self.register_selenium_firefox(profile = nil)
         ::Capybara.register_driver :selenium_billy do |app|
           profile ||= Selenium::WebDriver::Firefox::Profile.new
           profile.assume_untrusted_certificate_issuer = false
@@ -74,7 +74,7 @@ module Billy
       # Register chrome with a proxy
       # @param options [Capybara::WebDriver::Chrome::Options] the options
       # to pass to the driver
-      def self.register_selenium_chrome(options)
+      def self.register_selenium_chrome(options = nil)
         ::Capybara.register_driver :selenium_chrome_billy do |app|
           options ||= Selenium::WebDriver::Chrome::Options.new
           options.add_argument(

--- a/lib/billy/browsers/capybara.rb
+++ b/lib/billy/browsers/capybara.rb
@@ -2,13 +2,15 @@ require 'billy'
 
 module Billy
   module Browsers
+    # Additional methods for Capybara
     class Capybara
       DRIVERS = {
         poltergeist: 'capybara/poltergeist',
         webkit: 'capybara/webkit',
         selenium: 'selenium/webdriver'
-      }
+      }.freeze
 
+      # Register proxy drivers
       def self.register_drivers
         DRIVERS.each do |name, driver|
           begin
@@ -19,6 +21,8 @@ module Billy
         end
       end
 
+      # Register poltergeist with a proxy
+      # @param options [Hash] the options to pass to the driver
       def self.register_poltergeist_driver(options = {})
         ::Capybara.register_driver :poltergeist_billy do |app|
           options.merge(
@@ -31,6 +35,8 @@ module Billy
         end
       end
 
+      # Register webkit with a proxy
+      # @param options [Hash] the options to pass to the driver
       def self.register_webkit_driver(options = {})
         ::Capybara.register_driver :webkit_billy do |app|
           options.merge(
@@ -44,11 +50,15 @@ module Billy
         end
       end
 
+      # Register selenium with a proxy
       def self.register_selenium_driver
         register_selenium_firefox
         register_selenium_chrome
       end
 
+      # Register firefox with a proxy
+      # @param profile [Capybara::WebDriver::Firefox::Profile] the profile
+      # to pass to the driver
       def self.register_selenium_firefox(profile)
         ::Capybara.register_driver :selenium_billy do |app|
           profile ||= Selenium::WebDriver::Firefox::Profile.new
@@ -61,6 +71,9 @@ module Billy
         end
       end
 
+      # Register chrome with a proxy
+      # @param options [Capybara::WebDriver::Chrome::Options] the options
+      # to pass to the driver
       def self.register_selenium_chrome(options)
         ::Capybara.register_driver :selenium_chrome_billy do |app|
           options ||= Selenium::WebDriver::Chrome::Options.new

--- a/lib/billy/browsers/capybara.rb
+++ b/lib/billy/browsers/capybara.rb
@@ -54,18 +54,19 @@ module Billy
       end
 
       # Register firefox with a proxy
-      # @param profile [Capybara::WebDriver::Firefox::Profile] the profile
+      # @param profile [Capybara::WebDriver::Firefox::Options] the options
       # to pass to the driver
-      def self.register_selenium_firefox(profile = nil)
+      def self.register_selenium_firefox(options = nil)
         require 'selenium/webdriver'
         ::Capybara.register_driver :selenium_billy do |app|
-          profile ||= Selenium::WebDriver::Firefox::Profile.new
+          options ||= Selenium::WebDriver::Firefox::Options.new
+          profile = options.profile || Selenium::WebDriver::Firefox::Profile.new
           profile.assume_untrusted_certificate_issuer = false
           profile.proxy = Selenium::WebDriver::Proxy.new(
             http: "#{Billy.proxy.host}:#{Billy.proxy.port}",
             ssl: "#{Billy.proxy.host}:#{Billy.proxy.port}"
           )
-          ::Capybara::Selenium::Driver.new(app, profile: profile)
+          ::Capybara::Selenium::Driver.new(app, options: options)
         end
       end
 

--- a/lib/billy/browsers/capybara.rb
+++ b/lib/billy/browsers/capybara.rb
@@ -3,7 +3,6 @@ require 'billy'
 module Billy
   module Browsers
     class Capybara
-
       DRIVERS = {
         poltergeist: 'capybara/poltergeist',
         webkit: 'capybara/webkit',
@@ -20,49 +19,60 @@ module Billy
         end
       end
 
-      def self.register_poltergeist_driver
+      def self.register_poltergeist_driver(options = {})
         ::Capybara.register_driver :poltergeist_billy do |app|
-          options = {
+          options.merge(
             phantomjs_options: [
               '--ignore-ssl-errors=yes',
               "--proxy=#{Billy.proxy.host}:#{Billy.proxy.port}"
             ]
-          }
+          )
           ::Capybara::Poltergeist::Driver.new(app, options)
         end
       end
 
-      def self.register_webkit_driver
+      def self.register_webkit_driver(options = {})
         ::Capybara.register_driver :webkit_billy do |app|
-          options = {
+          options.merge(
             ignore_ssl_errors: true,
-            proxy: {host: Billy.proxy.host, port: Billy.proxy.port}
-          }
-          ::Capybara::Webkit::Driver.new(app, ::Capybara::Webkit::Configuration.to_hash.merge(options))
-        end
-      end
-
-      def self.register_selenium_driver
-        ::Capybara.register_driver :selenium_billy do |app|
-          profile = Selenium::WebDriver::Firefox::Profile.new
-          profile.assume_untrusted_certificate_issuer = false
-          profile.proxy = Selenium::WebDriver::Proxy.new(
-            http: "#{Billy.proxy.host}:#{Billy.proxy.port}",
-            ssl: "#{Billy.proxy.host}:#{Billy.proxy.port}")
-          ::Capybara::Selenium::Driver.new(app, profile: profile)
-        end
-
-        ::Capybara.register_driver :selenium_chrome_billy do |app|
-          options = Selenium::WebDriver::Chrome::Options.new
-          options.add_argument("--proxy-server=#{Billy.proxy.host}:#{Billy.proxy.port}")
-
-          ::Capybara::Selenium::Driver.new(
-            app, browser: :chrome,
-            options: options
+            proxy: { host: Billy.proxy.host, port: Billy.proxy.port }
+          )
+          ::Capybara::Webkit::Driver.new(
+            app,
+            ::Capybara::Webkit::Configuration.to_hash.merge(options)
           )
         end
       end
 
+      def self.register_selenium_driver
+        register_selenium_firefox
+        register_selenium_chrome
+      end
+
+      def self.register_selenium_firefox(profile)
+        ::Capybara.register_driver :selenium_billy do |app|
+          profile ||= Selenium::WebDriver::Firefox::Profile.new
+          profile.assume_untrusted_certificate_issuer = false
+          profile.proxy = Selenium::WebDriver::Proxy.new(
+            http: "#{Billy.proxy.host}:#{Billy.proxy.port}",
+            ssl: "#{Billy.proxy.host}:#{Billy.proxy.port}"
+          )
+          ::Capybara::Selenium::Driver.new(app, profile: profile)
+        end
+      end
+
+      def self.register_selenium_chrome(options)
+        ::Capybara.register_driver :selenium_chrome_billy do |app|
+          options ||= Selenium::WebDriver::Chrome::Options.new
+          options.add_argument(
+            "--proxy-server=#{Billy.proxy.host}:#{Billy.proxy.port}"
+          )
+
+          ::Capybara::Selenium::Driver.new(
+            app, browser: :chrome, options: options
+          )
+        end
+      end
     end
   end
 end

--- a/lib/billy/browsers/capybara.rb
+++ b/lib/billy/browsers/capybara.rb
@@ -20,8 +20,6 @@ module Billy
         end
       end
 
-      private
-
       def self.register_poltergeist_driver
         ::Capybara.register_driver :poltergeist_billy do |app|
           options = {

--- a/lib/billy/browsers/capybara.rb
+++ b/lib/billy/browsers/capybara.rb
@@ -25,7 +25,7 @@ module Billy
       # @param options [Hash] the options to pass to the driver
       def self.register_poltergeist_driver(options = {})
         ::Capybara.register_driver :poltergeist_billy do |app|
-          options.merge(
+          options = options.merge(
             phantomjs_options: [
               '--ignore-ssl-errors=yes',
               "--proxy=#{Billy.proxy.host}:#{Billy.proxy.port}"
@@ -39,7 +39,7 @@ module Billy
       # @param options [Hash] the options to pass to the driver
       def self.register_webkit_driver(options = {})
         ::Capybara.register_driver :webkit_billy do |app|
-          options.merge(
+          options = options.merge(
             ignore_ssl_errors: true,
             proxy: { host: Billy.proxy.host, port: Billy.proxy.port }
           )

--- a/lib/billy/browsers/capybara.rb
+++ b/lib/billy/browsers/capybara.rb
@@ -4,18 +4,13 @@ module Billy
   module Browsers
     # Additional methods for Capybara
     class Capybara
-      DRIVERS = {
-        poltergeist: 'capybara/poltergeist',
-        webkit: 'capybara/webkit',
-        selenium: 'selenium/webdriver'
-      }.freeze
+      DRIVERS = %w[poltergeist webkit selenium]
 
       # Register proxy drivers
       def self.register_drivers
-        DRIVERS.each do |name, driver|
+        DRIVERS.each do |name|
           begin
-            require driver
-            send("register_#{name}_driver")
+            send("register_#{name.to_s}_driver")
           rescue LoadError
           end
         end
@@ -24,6 +19,7 @@ module Billy
       # Register poltergeist with a proxy
       # @param options [Hash] the options to pass to the driver
       def self.register_poltergeist_driver(options = {})
+        require 'capybara/poltergeist'
         ::Capybara.register_driver :poltergeist_billy do |app|
           options = options.merge(
             phantomjs_options: [
@@ -38,6 +34,7 @@ module Billy
       # Register webkit with a proxy
       # @param options [Hash] the options to pass to the driver
       def self.register_webkit_driver(options = {})
+        require 'capybara/webkit'
         ::Capybara.register_driver :webkit_billy do |app|
           options = options.merge(
             ignore_ssl_errors: true,
@@ -60,6 +57,7 @@ module Billy
       # @param profile [Capybara::WebDriver::Firefox::Profile] the profile
       # to pass to the driver
       def self.register_selenium_firefox(profile = nil)
+        require 'selenium/webdriver'
         ::Capybara.register_driver :selenium_billy do |app|
           profile ||= Selenium::WebDriver::Firefox::Profile.new
           profile.assume_untrusted_certificate_issuer = false
@@ -75,6 +73,7 @@ module Billy
       # @param options [Capybara::WebDriver::Chrome::Options] the options
       # to pass to the driver
       def self.register_selenium_chrome(options = nil)
+        require 'selenium/webdriver'
         ::Capybara.register_driver :selenium_chrome_billy do |app|
           options ||= Selenium::WebDriver::Chrome::Options.new
           options.add_argument(


### PR DESCRIPTION
This PR adds the ability to customize the profiles/options used when registering the Capybara proxy drivers.

For users that follow the guide and simply ```require 'billy/capybara/rspec'```, the existing behavior is unchanged.

For users that need something customized -- i.e., the ability to disable image loading -- the individual driver registration methods can be called with an option/profile object. If an object is passed,  the registration method appends the proxy information where appropriate and uses the passed option/profile object when creating the proxy driver.

The ability to customize profiles and options appears to be present for the Watir:: browsers already; this should establish parity between the proxies for the two libraries.