### PR TITLE
Add after suite stop hook for event machine

### DIFF
--- a/lib/billy/init/rspec.rb
+++ b/lib/billy/init/rspec.rb
@@ -9,7 +9,11 @@ end
 RSpec.configure do |config|
   config.include(Billy::RspecHelper)
 
-  config.prepend_after(:each) do
+  config.append_after(:each) do
     proxy.reset
+  end
+
+  config.after(:suite) do
+    Billy.proxy.stop
   end
 end


### PR DESCRIPTION
Let's explicitly shutdown event machine after our test suite has run.

Closes https://github.com/oesmith/puffing-billy/issues/237