### PR TITLE
Don't  attempt to print backtrace when it's not available (EM event handler)

### DIFF
--- a/lib/billy/proxy.rb
+++ b/lib/billy/proxy.rb
@@ -70,7 +70,7 @@ module Billy
       EM.run do
         EM.error_handler do |e|
           Billy.log :error, "#{e.class} (#{e.message}):"
-          Billy.log :error, e.backtrace.join("\n")
+          Billy.log :error, e.backtrace.join("\n") unless e.backtrace.nil?
         end
 
         @signature = EM.start_server(host, Billy.config.proxy_port, ProxyConnection) do |p|


### PR DESCRIPTION
Hello,
Looks like `Exception`s are allowed to not have backtrace available

Trying to `join()` on nil terminates puffing billy so I think it's feasible to check whether exception has backtrace before atttempting to print it 

I had some problems with `puffing-billy` terminating because of exception in main_loop thread what caused it to terminate and as a consequence -  following tests in suite to fail because proxy has just died so no requests passed through it would receive a response