### PR TITLE
Update eventmachine gem

### DIFF
--- a/puffing-billy.gemspec
+++ b/puffing-billy.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'cucumber'
   gem.add_development_dependency 'watir', '~> 6.10.0'
   gem.add_runtime_dependency 'addressable', '~> 2.5'
-  gem.add_runtime_dependency 'eventmachine', '~> 1.0.4'
+  gem.add_runtime_dependency 'eventmachine', '~> 1.2'
   gem.add_runtime_dependency 'em-synchrony'
   gem.add_runtime_dependency 'em-http-request', '~> 1.1', '>= 1.1.0'
   gem.add_runtime_dependency 'eventmachine_httpserver'

--- a/spec/support/test_server.rb
+++ b/spec/support/test_server.rb
@@ -35,9 +35,9 @@ module Billy
         end
       end
 
-      @http_url  = "http://localhost:#{q.pop}"
-      @https_url = "https://localhost:#{q.pop}"
-      @error_url = "http://localhost:#{q.pop}"
+      @http_url  = "http://127.0.0.1:#{q.pop}"
+      @https_url = "https://127.0.0.1:#{q.pop}"
+      @error_url = "http://127.0.0.1:#{q.pop}"
     end
 
     def echo_app_setup(response_code = 200)


### PR DESCRIPTION
As I mentioned in #217, 1.0.x versions of `eventmachine` mean that Puffing Billy cannot be used when dealing with resources over HTTP/2, but I see that the version of `eventmachine` was set back again in #212 due to compatibility issues with `watir`. I want to use the latest version of Puffing Billy in order to get access to some of the new features, so I'm going to try bumping `eventmachine` again.

All of the unit tests passed for me, once I made the small change here in `test_server.rb`. This looks similar to the issue I described in #217 where `localhost` won't work, but `127.0.0.1` will.