### PR TITLE
Add support for response code

### DIFF
--- a/lib/billy/handlers/request_handler.rb
+++ b/lib/billy/handlers/request_handler.rb
@@ -20,7 +20,7 @@ module Billy
       # Process the handlers by order of importance
       [:stubs, :cache, :proxy].each do |key|
         if (response = handlers[key].handle_request(method, url, headers, body))
-          @request_log.complete(request, key)
+          @request_log.complete(request, response, key)
           return response
         end
       end

--- a/lib/billy/handlers/request_log.rb
+++ b/lib/billy/handlers/request_log.rb
@@ -26,11 +26,12 @@ module Billy
       request
     end
 
-    def complete(request, handler)
+    def complete(request, response, handler)
       return unless Billy.config.record_requests
 
       request.merge! status: :complete,
-                     handler: handler
+                     handler: handler,
+                     code: response[:status]
     end
   end
 end


### PR DESCRIPTION
We're using your gem to enhance feature test development by warning developers when they have failed requests. This change adds the response code which we can use to log when there's an error.