### PR TITLE
Update CHANGELOG and version for 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v2.0.0, 2019-01-30
+-------------------
+  * Add driver registration for apparition driver [#258](https://github.com/oesmith/puffing-billy/pull/258)
+    * Apparition driver requires puffing-billy to drop support for ruby 2.0-2.2
+
 v1.1.3, 2019-01-07
 -------------------
   * Update eventmachine gem from 1.0.4 to 1.2 [#251](https://github.com/oesmith/puffing-billy/pull/251)

--- a/lib/billy/version.rb
+++ b/lib/billy/version.rb
@@ -1,3 +1,3 @@
 module Billy
-  VERSION = '1.1.3'
+  VERSION = '2.0.0'
 end


### PR DESCRIPTION
Drops support for ruby 2.0, 2.1, and 2.2.