### PR TITLE
Update README to include making scenario spec-specific folders via Rspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,10 +519,11 @@ RSpec.configure do |config|
 end
 ```
 
-## Separate Cache Directory for Each Test (in Cucumber)
+## Separate Cache Directory for Each Test
+If you want the cache for each test to be independent, i.e. have it's own directory where the cache files are stored, you can do so.
 
-If you want the cache for each test to be independent, i.e. have it's own directory where the cache files are stored, you can use a Before tag like so:
-
+### in Cucumber
+use a Before tag:
 ```rb
 Before('@javascript') do |scenario, block|
   Billy.configure do |c|
@@ -533,6 +534,29 @@ Before('@javascript') do |scenario, block|
   end
 end
 ```
+
+### in Rspec
+use a before(:each) block:
+```rb
+RSpec.configure do |config|
+  base_cache_path = Billy.config.cache_path
+  base_certs_path = Billy.config.certs_path
+  config.before :each do |x|
+    feature_name = x.metadata[:example_group][:description].underscore.gsub(' ', '_')
+    scenario_name = x.metadata[:description].underscore.gsub(' ', '_')
+    Billy.configure do |c|
+      cache_scenario_folder_path = "#{base_cache_path}/#{feature_name}/#{scenario_name}/"
+      FileUtils.mkdir_p(cache_scenario_folder_path) unless File.exist?(cache_scenario_folder_path)
+      c.cache_path = cache_scenario_folder_path
+
+      certs_scenario_folder_path = "#{base_certs_path}/#{feature_name}/#{scenario_name}/"
+      FileUtils.mkdir_p(certs_scenario_folder_path) unless File.exist?(certs_scenario_folder_path)
+      c.certs_path = certs_scenario_folder_path
+    end
+  end
+end
+```
+
 
 ## Stub requests recording
 


### PR DESCRIPTION
Cucumber instructions were already included in README.MD. This adds similar instructions for RSPEC to maintain parity between the two.