### PR TITLE
Allow intercepting requests with any method

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,9 @@ proxy.stub('https://example.com/proc/').and_return(Proc.new { |params, headers, 
 # a Proc and use the pass_request method. You can manipulate the request
 # (headers, URL, HTTP method, etc) and also the response from the upstream
 # server. The scope of the delivered callable is the user scope where
-# it was defined.
-proxy.stub('http://example.com/').and_return(Proc.new { |*args|
+# it was defined. Setting method to 'all' will intercept requests regardless of
+# the method.
+proxy.stub('http://example.com/', method => 'all').and_return(Proc.new { |*args|
   response = Billy.pass_request(*args)
   response[:headers]['Content-Type'] = 'text/plain'
   response[:body] = 'Hello World!'

--- a/lib/billy/proxy_request_stub.rb
+++ b/lib/billy/proxy_request_stub.rb
@@ -62,7 +62,7 @@ module Billy
     end
 
     def matches?(method, url)
-      if method == @method
+      if @method == 'ALL' || method == @method
         if @url.is_a?(Regexp)
           url.match(@url)
         else

--- a/spec/lib/billy/proxy_request_stub_spec.rb
+++ b/spec/lib/billy/proxy_request_stub_spec.rb
@@ -43,6 +43,17 @@ describe Billy::ProxyRequestStub do
       expect(stub.matches?('GET', 'http://example.com/foo/bar/')).to be
       expect(stub.matches?('GET', 'http://example.com/foo/bar/?baz=bap')).to be
     end
+
+    it 'should match all methods' do
+      expect(Billy::ProxyRequestStub.new('http://example.com', method: :all)
+        .matches?('GET', 'http://example.com')).to be
+      expect(Billy::ProxyRequestStub.new('http://example.com', method: :all)
+        .matches?('POST', 'http://example.com')).to be
+      expect(Billy::ProxyRequestStub.new('http://example.com', method: :all)
+        .matches?('OPTIONS', 'http://example.com')).to be
+      expect(Billy::ProxyRequestStub.new('http://example.com', method: :all)
+        .matches?('HEAD', 'http://example.com')).to be
+    end
   end
 
   context "#matches? (with strip_query_params false in config)" do


### PR DESCRIPTION
Add a new value `all` to proxy stub handler's `method` option that will intercept all requests regardless of the method.