### PR TITLE
Accept all encodings

### DIFF
--- a/lib/billy/handlers/proxy_handler.rb
+++ b/lib/billy/handlers/proxy_handler.rb
@@ -67,7 +67,7 @@ module Billy
 
     def build_request_options(url, headers, body)
       headers = Hash[headers.map { |k, v| [k.downcase, v] }]
-      headers.delete('accept-encoding')
+      headers['accept-encoding'] = ''
 
       uri = Addressable::URI.parse(url)
       headers.merge!({'authorization' => [uri.user, uri.password]}) if uri.userinfo


### PR DESCRIPTION
I was experiencing the same issue as in https://github.com/oesmith/puffing-billy/issues/204 which seems to be due to puffing billy being unable to decode a response.

I eventually stumbled across a PR that addresses this issue (https://github.com/oesmith/puffing-billy/pull/167) by setting the `accept-encoding` header to a blank string instead of deleting it. According to @damned, the root cause is the `em-http-request` library which sets the `accept-encoding` header if it's not present. Once I made this change, the `Content-decoder` error disappeared.
