### PR TITLE
Add driver registration for chrome headless

### DIFF
--- a/lib/billy/browsers/capybara.rb
+++ b/lib/billy/browsers/capybara.rb
@@ -64,6 +64,17 @@ module Billy
             options: options
           )
         end
+        
+        ::Capybara.register_driver :selenium_chrome_headless_billy do |app|
+          options = Selenium::WebDriver::Chrome::Options.new(args: %w[headless disable-gpu no-sandbox
+                                                                      enable-features=NetworkService,NetworkServiceInProcess])
+          options.add_argument("--proxy-server=#{Billy.proxy.host}:#{Billy.proxy.port}")
+
+          ::Capybara::Selenium::Driver.new(
+            app, browser: :chrome,
+            options: options
+          )
+        end
       end
 
       def self.register_apparition_driver


### PR DESCRIPTION
Chrome headless driver registration along with time-out bug fix for ChromeDriver v74.0.3729.6 in headless mode.