### PR TITLE
Add selenium_chrome_headless_billy to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ require 'billy/capybara/rspec'
 # select a driver for your chosen browser environment
 Capybara.javascript_driver = :selenium_billy # Uses Firefox
 # Capybara.javascript_driver = :selenium_chrome_billy
+# Capybara.javascript_driver = :selenium_chrome_headless_billy
 # Capybara.javascript_driver = :apparition_billy
 # Capybara.javascript_driver = :webkit_billy
 # Capybara.javascript_driver = :poltergeist_billy


### PR DESCRIPTION
It looks like the `:selenium_chrome_headless_billy` driver was added to this project recently, but not documented yet in the README.