### PR TITLE
Add Selenium headless driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ require 'billy/capybara/rspec'
 
 # select a driver for your chosen browser environment
 Capybara.javascript_driver = :selenium_billy # Uses Firefox
+# Capybara.javascript_driver = :selenium_headless_billy # Uses Firefox in headless mode
 # Capybara.javascript_driver = :selenium_chrome_billy
 # Capybara.javascript_driver = :selenium_chrome_headless_billy
 # Capybara.javascript_driver = :apparition_billy

--- a/lib/billy/browsers/capybara.rb
+++ b/lib/billy/browsers/capybara.rb
@@ -98,7 +98,7 @@ module Billy
             ssl: "#{Billy.proxy.host}:#{Billy.proxy.port}")
         end
 
-        options = Selenium::WebDriver::Firefox::Options.new(profile: profile)
+        Selenium::WebDriver::Firefox::Options.new(profile: profile)
       end
     end
   end

--- a/lib/billy/browsers/capybara.rb
+++ b/lib/billy/browsers/capybara.rb
@@ -48,16 +48,18 @@ module Billy
       def self.register_selenium_driver
         ::Capybara.register_driver :selenium_billy do |app|
           options = build_selenium_options_for_firefox
-          
-          ::Capybara::Selenium::Driver.new(app, options: options)
+          capabilities = Selenium::WebDriver::Remote::Capabilities.firefox(accept_insecure_certs: true)
+
+          ::Capybara::Selenium::Driver.new(app, options: options, desired_capabilities: capabilities)
         end
 
         ::Capybara.register_driver :selenium_headless_billy do |app|
           options = build_selenium_options_for_firefox.tap do |opts|
             opts.add_argument '-headless'
           end
+          capabilities = Selenium::WebDriver::Remote::Capabilities.firefox(accept_insecure_certs: true)
           
-          ::Capybara::Selenium::Driver.new(app, options: options)
+          ::Capybara::Selenium::Driver.new(app, options: options, desired_capabilities: capabilities)
         end
 
         ::Capybara.register_driver :selenium_chrome_billy do |app|

--- a/lib/billy/browsers/capybara.rb
+++ b/lib/billy/browsers/capybara.rb
@@ -47,12 +47,15 @@ module Billy
 
       def self.register_selenium_driver
         ::Capybara.register_driver :selenium_billy do |app|
-          profile = Selenium::WebDriver::Firefox::Profile.new
-          profile.assume_untrusted_certificate_issuer = false
-          profile.proxy = Selenium::WebDriver::Proxy.new(
-            http: "#{Billy.proxy.host}:#{Billy.proxy.port}",
-            ssl: "#{Billy.proxy.host}:#{Billy.proxy.port}")
-          ::Capybara::Selenium::Driver.new(app, profile: profile)
+          profile = Selenium::WebDriver::Firefox::Profile.new.tap do |prof|
+            prof.assume_untrusted_certificate_issuer = false
+            prof.proxy = Selenium::WebDriver::Proxy.new(
+              http: "#{Billy.proxy.host}:#{Billy.proxy.port}",
+              ssl: "#{Billy.proxy.host}:#{Billy.proxy.port}")
+          end
+          options = Selenium::WebDriver::Firefox::Options.new(profile: profile)
+          
+          ::Capybara::Selenium::Driver.new(app, options: options)
         end
 
         ::Capybara.register_driver :selenium_chrome_billy do |app|

--- a/lib/billy/browsers/capybara.rb
+++ b/lib/billy/browsers/capybara.rb
@@ -47,13 +47,15 @@ module Billy
 
       def self.register_selenium_driver
         ::Capybara.register_driver :selenium_billy do |app|
-          profile = Selenium::WebDriver::Firefox::Profile.new.tap do |prof|
-            prof.assume_untrusted_certificate_issuer = false
-            prof.proxy = Selenium::WebDriver::Proxy.new(
-              http: "#{Billy.proxy.host}:#{Billy.proxy.port}",
-              ssl: "#{Billy.proxy.host}:#{Billy.proxy.port}")
+          options = build_selenium_options_for_firefox
+          
+          ::Capybara::Selenium::Driver.new(app, options: options)
+        end
+
+        ::Capybara.register_driver :selenium_headless_billy do |app|
+          options = build_selenium_options_for_firefox.tap do |opts|
+            opts.add_argument '-headless'
           end
-          options = Selenium::WebDriver::Firefox::Options.new(profile: profile)
           
           ::Capybara::Selenium::Driver.new(app, options: options)
         end
@@ -86,6 +88,17 @@ module Billy
             driver.set_proxy(Billy.proxy.host, Billy.proxy.port)
           end
         end
+      end
+
+      def self.build_selenium_options_for_firefox
+        profile = Selenium::WebDriver::Firefox::Profile.new.tap do |prof|
+          prof.assume_untrusted_certificate_issuer = false
+          prof.proxy = Selenium::WebDriver::Proxy.new(
+            http: "#{Billy.proxy.host}:#{Billy.proxy.port}",
+            ssl: "#{Billy.proxy.host}:#{Billy.proxy.port}")
+        end
+
+        options = Selenium::WebDriver::Firefox::Options.new(profile: profile)
       end
     end
   end


### PR DESCRIPTION
# Background
The `selenium_billy` driver doesn't appear to support headless mode, and also (though unrelated) throws a `Selenium [DEPRECATION] :profile is deprecated. Use Selenium::WebDriver::Firefox::Options#profile= instead.` warning.

# Summary
I've simply refactored the `selenium_billy` driver so that we're no longer using the deprecated method of setting a profile, and then added a `selenium_headless_billy` driver with headless support.