### PR TITLE
Add `cache_whitelist` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ server = Capybara.current_session.server
 Billy.config.whitelist = ["#{server.host}:#{server.port}"]
 ```
 
+If you would like to cache whitelisted URLs, you can define them in `c.cache_whitelist`. This is useful for scenarios where you may want to set `c.non_whitelisted_requests_disabled` to `true` to only allow whitelisted URLs to be accessed, but still allow specific URLs to be treated as if they were non-whitelisted.
+
 If you want to use puffing-billy like you would [VCR](https://github.com/vcr/vcr)
 you can turn on cache persistence. This way you don't have to manually mock out
 everything as requests are automatically recorded and played back. With cache
@@ -292,6 +294,7 @@ Billy.configure do |c|
   c.proxy_port = 12345 # defaults to random
   c.proxied_request_host = nil
   c.proxied_request_port = 80
+  c.proxied_whitelist = []
   c.record_requests = true # defaults to false
   c.cache_request_body_methods = ['post', 'patch', 'put'] # defaults to ['post']
 end

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Billy.configure do |c|
   c.proxy_port = 12345 # defaults to random
   c.proxied_request_host = nil
   c.proxied_request_port = 80
-  c.proxied_whitelist = []
+  c.cache_whitelist = []
   c.record_requests = true # defaults to false
   c.cache_request_body_methods = ['post', 'patch', 'put'] # defaults to ['post']
 end

--- a/lib/billy/config.rb
+++ b/lib/billy/config.rb
@@ -6,7 +6,7 @@ module Billy
     DEFAULT_WHITELIST = ['127.0.0.1', 'localhost']
     RANDOM_AVAILABLE_PORT = 0 # https://github.com/eventmachine/eventmachine/wiki/FAQ#wiki-can-i-start-a-server-on-a-random-available-port
 
-    attr_accessor :logger, :cache, :cache_request_headers, :whitelist, :path_blacklist, :ignore_params, :allow_params,
+    attr_accessor :logger, :cache, :cache_request_headers, :whitelist, :cache_whitelist, :path_blacklist, :ignore_params, :allow_params,
                   :persist_cache, :ignore_cache_port, :non_successful_cache_disabled, :non_successful_error_level,
                   :non_whitelisted_requests_disabled, :cache_path, :certs_path, :proxy_host, :proxy_port, :proxied_request_inactivity_timeout,
                   :proxied_request_connect_timeout, :dynamic_jsonp, :dynamic_jsonp_keys, :dynamic_jsonp_callback_name, :merge_cached_responses_whitelist,
@@ -21,6 +21,7 @@ module Billy
     def reset
       @cache = true
       @cache_request_headers = false
+      @cache_whitelist = []
       @whitelist = DEFAULT_WHITELIST
       @path_blacklist = []
       @merge_cached_responses_whitelist = []

--- a/lib/billy/handlers/proxy_handler.rb
+++ b/lib/billy/handlers/proxy_handler.rb
@@ -110,11 +110,21 @@ module Billy
 
       url = Addressable::URI.parse(url)
       # Cache the responses if they aren't whitelisted host[:port]s but always cache blacklisted paths on any hosts
-      cacheable_status?(status) && (!whitelisted_url?(url) || blacklisted_path?(url.path))
+      cacheable_status?(status) && (!whitelisted_url?(url) || blacklisted_path?(url.path) || cache_whitelisted_url?(url))
     end
 
     def whitelisted_url?(url)
       Billy.config.whitelist.any? do |value|
+        if value.is_a?(Regexp)
+          url.to_s =~ value || url.omit(:port).to_s =~ value
+        else
+          value =~ /^#{url.host}(?::#{url.port})?$/
+        end
+      end
+    end
+
+    def cache_whitelisted_url?(url)
+      Billy.config.cache_whitelist.any? do |value|
         if value.is_a?(Regexp)
           url.to_s =~ value || url.omit(:port).to_s =~ value
         else

--- a/spec/lib/billy/handlers/proxy_handler_spec.rb
+++ b/spec/lib/billy/handlers/proxy_handler_spec.rb
@@ -175,6 +175,34 @@ describe Billy::ProxyHandler do
                                request[:body])
       end
 
+      it 'does NOT cache the response if the host is whitelisted but not cache_whitelisted' do
+        uri = Addressable::URI.parse(request[:url])
+
+        expect(subject).to receive(:allowed_response_code?).and_return(true)
+        expect(Billy.config).to receive(:whitelist).and_return([uri.host])
+        expect(Billy.config).to receive(:cache_whitelist).and_return([])
+
+        expect(Billy::Cache.instance).not_to receive(:store)
+        subject.handle_request(request[:method],
+                               request[:url],
+                               request[:headers],
+                               request[:body])
+      end
+
+      it 'caches the response if the host is whitelisted AND cache_whitelisted' do
+        uri = Addressable::URI.parse(request[:url])
+
+        expect(subject).to receive(:allowed_response_code?).and_return(true)
+        expect(Billy.config).to receive(:whitelist).and_return([uri.host])
+        expect(Billy.config).to receive(:cache_whitelist).and_return([uri.host])
+
+        expect(Billy::Cache.instance).to receive(:store)
+        subject.handle_request(request[:method],
+                               request[:url],
+                               request[:headers],
+                               request[:body])
+      end
+
       it 'uses the timeouts defined in configuration' do
         allow(Billy.config).to receive(:proxied_request_inactivity_timeout).and_return(42)
         allow(Billy.config).to receive(:proxied_request_connect_timeout).and_return(24)

--- a/spec/lib/proxy_spec.rb
+++ b/spec/lib/proxy_spec.rb
@@ -118,6 +118,29 @@ shared_examples_for 'a cache' do
     end
   end
 
+  context 'cache_whitelist GET requests' do
+    before do
+      Billy.config.whitelist = [http.host]
+      Billy.config.cache_whitelist = [http.host]
+    end
+
+    it 'should be cached' do
+      assert_cached_url
+    end
+
+    context 'with ports' do
+      before do
+        rack_app_url = URI(http.url_prefix)
+        Billy.config.whitelist = ["#{rack_app_url.host}:#{rack_app_url.port + 1}"]
+        Billy.config.cache_whitelist = Billy.config.whitelist
+      end
+
+      it 'should be cached' do
+        assert_cached_url
+      end
+    end
+  end
+
   context 'ignore_params GET requests' do
     before do
       Billy.config.ignore_params = ['/analytics']


### PR DESCRIPTION
# Background
Currently, for a URL to be cacheable, it must have a cacheable HTTP response code and:

- Must be a non-whitelisted URL, or
- Must be a blacklisted path

The problem with this is that sometimes you may want to force a whitelisted host to also be cacheable. For example, in one application I'm working on, I'd like to block _all_ external requests using `c.non_whitelisted_requests_disabled`, but allow specific hosts to be cached so that I can use Puffing-Billy as I would VCR.

Logically, when using `c.non_whitelisted_requests_disabled` only whitelisted requests are enabled. Unfortunately, however, whitelisted URLs are never cached, so I have two options:
1)  Set `c.non_whitelisted_requests_disabled` to `false` and cache _all_ requests, OR
2)  Abandon my plan to use Puffing-billy as I would VCR, and just stub requests manually.

# Solution
- Added a `cache_whitelist` config option which functions in the same way as `whitelist`.
- When determining whether a request is cacheable, the Proxy Handler now takes into account whether the URL is in the `c.cache_whitelist` array.