### PR TITLE
Ignore certificate errors in Chrome

### DIFF
--- a/examples/tumblr_api_https.html
+++ b/examples/tumblr_api_https.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<body>
+  <h1>Latest news</h1>
+  <div id="news"></div>
+
+  <script type='text/javascript' src='http://code.jquery.com/jquery-1.8.2.min.js'></script>
+  <script type='text/javascript'>
+  $(function () {
+    var url = 'https://blog.howmanyleft.co.uk/api/read/json?callback=?&type=text&num=3&filter=text';
+    $.getJSON(url, function (data) {
+      $.each(data.posts, function (idx, post) {
+        var title = post['regular-title'];
+        var href = post['url-with-slug'];
+        var body = post['regular-body'];
+        $('#news').append(
+          '<h3><a href="' + href + '">' + title + '</a></h3>' +
+          '<p>' + body + '</p>');
+      });
+    });
+  })
+  </script>
+</body>

--- a/lib/billy/browsers/capybara.rb
+++ b/lib/billy/browsers/capybara.rb
@@ -64,6 +64,7 @@ module Billy
 
         ::Capybara.register_driver :selenium_chrome_billy do |app|
           options = Selenium::WebDriver::Chrome::Options.new
+          options.add_argument('--ignore-certificate-errors')
           options.add_argument("--proxy-server=#{Billy.proxy.host}:#{Billy.proxy.port}")
 
           ::Capybara::Selenium::Driver.new(
@@ -79,6 +80,7 @@ module Billy
             options = Selenium::WebDriver::Chrome::Options.new
             options.headless!
             options.add_argument('--enable-features=NetworkService,NetworkServiceInProcess')
+            options.add_argument('--ignore-certificate-errors')
             options.add_argument("--proxy-server=#{Billy.proxy.host}:#{Billy.proxy.port}")
             options.add_argument('--disable-gpu') if Gem.win_platform?
             options.add_argument('--no-sandbox') if ENV['CI']

--- a/spec/lib/billy/browsers/capybara_spec.rb
+++ b/spec/lib/billy/browsers/capybara_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'Capybara drivers', type: :feature, js: true do
+  it 'allows HTTPS calls' do
+    proxy.stub('https://blog.howmanyleft.co.uk:443/api/read/json').and_return(
+      jsonp: {
+        posts: [
+          {
+            'regular-title' => 'News Item 1',
+            'url-with-slug' => 'http://example.com/news/1',
+            'regular-body' => 'News item 1 content here'
+          },
+          {
+            'regular-title' => 'News Item 2',
+            'url-with-slug' => 'http://example.com/news/2',
+            'regular-body' => 'News item 2 content here'
+          }
+        ]
+      })
+
+    visit '/tumblr_api_https.html'
+
+    expect(page).to have_link('News Item 1', href: 'http://example.com/news/1')
+    expect(page).to have_content('News item 1 content here')
+    expect(page).to have_link('News Item 2', href: 'http://example.com/news/2')
+    expect(page).to have_content('News item 2 content here')
+  end
+end


### PR DESCRIPTION
After upgrading Chrome to version 79, our app's test suite started producing a steady stream of warnings like the following one:

```
140361933186816:error:14094416:SSL routines:ssl3_read_bytes:sslv3 alert certificate unknown:s3_pkt.c:1487:SSL alert number 46
```

Additionally, all actual HTTPS requests fail, which, in turn, fails our tests expecting those requests to be successful.

I'm not sure what exact change in Chrome triggered the warning that wasn't showing before, but the only two ways to remove it are:

* Add the `ignore-certificate-errors` flag to Chrome
* Stop using Puffing Billy

Since not using Puffing Billy is not really an option, we can only ask Chrome to ignore all certificate errors. This clears the warnings and makes the tests expecting HTTPS requests to succeed to pass.

Also added a spec that fails on the current `master` branch without ignoring client certificates:

```
$ bundle exec rspec spec/lib/billy/browsers/capybara_spec.rb                                                                                                                                            -- INSERT --
I, [2019-12-11T21:11:23.806160 #19316]  INFO -- : puffing-billy: Proxy listening on http://localhost:61104
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 46748
123145571295404:error:14094416:SSL routines:ssl3_read_bytes:sslv3 alert certificate unknown:s3_pkt.c:1498:SSL alert number 46
F

Failures:

  1) Capybara drivers allows HTTPS calls
     Failure/Error: expect(page).to have_link('News Item 1', href: 'http://example.com/news/1')
       expected to find link "News Item 1" with href "http://example.com/news/1" but there were no matches
     # ./spec/lib/billy/browsers/capybara_spec.rb:23:in `block (2 levels) in <top (required)>'

Finished in 3.39 seconds (files took 1.43 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/lib/billy/browsers/capybara_spec.rb:4 # Capybara drivers allows HTTPS calls
```