### PR TITLE
Update min 'faraday' gem version required

### DIFF
--- a/puffing-billy.gemspec
+++ b/puffing-billy.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'thin'
-  gem.add_development_dependency 'faraday'
+  gem.add_development_dependency 'faraday', '>= 0.9.0'
   gem.add_development_dependency 'apparition'
   gem.add_development_dependency 'capybara'
   gem.add_development_dependency 'selenium-webdriver'

--- a/spec/lib/proxy_spec.rb
+++ b/spec/lib/proxy_spec.rb
@@ -255,7 +255,7 @@ shared_examples_for 'a cache' do
 
         it 'should raise error when disabled' do
           # TODO: Suppress stderr output: https://gist.github.com/adamstegman/926858
-          expect { http.get('/foo') }.to raise_error(Faraday::Error::ConnectionFailed, 'end of file reached')
+          expect { http.get('/foo') }.to raise_error(Faraday::ConnectionFailed, 'end of file reached')
         end
       end
 
@@ -284,7 +284,7 @@ shared_examples_for 'a cache' do
         end
 
         it 'should raise error for non-successful responses when :error' do
-          expect { http_error.get('/foo') }.to raise_error(Faraday::Error::ConnectionFailed)
+          expect { http_error.get('/foo') }.to raise_error(Faraday::ConnectionFailed)
         end
       end
     end


### PR DESCRIPTION
This fixes the specs failure as `Faraday::Error::ConnectionFailed` has been deprecated, and later removed in 'faraday' v1.0.0, in favor of `Faraday::ConnectionFailed`