### PR TITLE
Include pid in names of temporary files

### DIFF
--- a/lib/billy/ssl/certificate_helpers.rb
+++ b/lib/billy/ssl/certificate_helpers.rb
@@ -27,7 +27,7 @@ module Billy
     # and ensure the location is safely created. Pass
     # back the resulting path.
     def write_file(name, contents)
-      path = File.join(Billy.config.certs_path, name)
+      path = File.join(Billy.config.certs_path, "#{Process.pid}-#{name}")
       FileUtils.mkdir_p(File.dirname(path))
       File.write(path, contents)
       path


### PR DESCRIPTION
When running puffing-billy in a parallel test environment (for instance, in Rails 6), frequent crashes occur, with errors like the following:

```
123145443577856:error:0909006C:PEM routines:get_name:no start line:crypto/pem/pem_lib.c:745:Expecting: TRUSTED CERTIFICATE
123145443577856:error:140DC009:SSL routines:use_certificate_chain_file:PEM lib:ssl/ssl_rsa.c:622:
Assertion failed: (e > 0), function SslContext_t, file ssl.cpp, line 203.
```

```
123145562779648:error:0909006C:PEM routines:get_name:no start line:crypto/pem/pem_lib.c:745:Expecting: ANY PRIVATE KEY
123145562779648:error:140B0009:SSL routines:SSL_CTX_use_PrivateKey_file:PEM lib:ssl/ssl_rsa.c:556:
Assertion failed: (e > 0), function SslContext_t, file ssl.cpp, line 196.
```

These errors occur because parallel puffing-billy processes will overwrite each other's certificate files. To solve the problem, I've prefixed the certificate filenames with the current process id.