### PR TITLE
Make verify_peer configurable and default it to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -740,6 +740,20 @@ the system store. So after a run of your the suite only one certificate will be
 left over. If this is not enough you can handling the cleanup again with a
 custom on-after hook.
 
+### TLS hostname validation
+
+em-http-request was modified to emit a warning if being used without the TLS
+``verify_peer`` option.  Puffing Billy defaults to specifying ``verify_peer: false``
+but you can now modify configuration to do peer verification. So if you've
+gone to the trouble of setting up your own certificate authority and self-signed
+certs you can enable it like so:
+
+```ruby
+Billy.configure do |c|
+  c.verify_peer = true
+end
+```
+
 ## Resources
 
 * [Bring Ruby VCR to Javascript testing with Capybara and puffing-billy](http://architects.dzone.com/articles/bring-ruby-vcr-javascript)

--- a/lib/billy/config.rb
+++ b/lib/billy/config.rb
@@ -8,7 +8,7 @@ module Billy
 
     attr_accessor :logger, :cache, :cache_request_headers, :whitelist, :cache_whitelist, :path_blacklist, :ignore_params, :allow_params,
                   :persist_cache, :ignore_cache_port, :non_successful_cache_disabled, :non_successful_error_level,
-                  :non_whitelisted_requests_disabled, :cache_path, :certs_path, :proxy_host, :proxy_port, :proxied_request_inactivity_timeout,
+                  :non_whitelisted_requests_disabled, :cache_path, :certs_path, :verify_peer, :proxy_host, :proxy_port, :proxied_request_inactivity_timeout,
                   :proxied_request_connect_timeout, :dynamic_jsonp, :dynamic_jsonp_keys, :dynamic_jsonp_callback_name, :merge_cached_responses_whitelist,
                   :strip_query_params, :proxied_request_host, :proxied_request_port, :cache_request_body_methods, :after_cache_handles_request,
                   :cache_simulates_network_delays, :cache_simulates_network_delay_time, :record_requests, :record_stub_requests, :use_ignore_params, :before_handle_request
@@ -37,6 +37,7 @@ module Billy
       @non_whitelisted_requests_disabled = false
       @cache_path = File.join(Dir.tmpdir, 'puffing-billy')
       @certs_path = File.join(Dir.tmpdir, 'puffing-billy', 'certs')
+      @verify_peer = false
       @proxy_host = 'localhost'
       @proxy_port = RANDOM_AVAILABLE_PORT
       @proxied_request_inactivity_timeout = 10 # defaults from https://github.com/igrigorik/em-http-request/wiki/Redirects-and-Timeouts

--- a/lib/billy/handlers/proxy_handler.rb
+++ b/lib/billy/handlers/proxy_handler.rb
@@ -16,6 +16,10 @@ module Billy
         opts = { inactivity_timeout: Billy.config.proxied_request_inactivity_timeout,
                  connect_timeout:    Billy.config.proxied_request_connect_timeout }
 
+        if url =~ /^https/
+          opts.merge!({tls: {verify_peer: Billy.config.verify_peer}})
+        end
+
         if Billy.config.proxied_request_host && !bypass_internal_proxy?(url)
           opts.merge!({ proxy: { host: Billy.config.proxied_request_host,
                                  port: Billy.config.proxied_request_port }} )


### PR DESCRIPTION
Resolves #293 

Also note that this doesn't make these warnings

```
[WARNING; em-http-request] TLS hostname validation is disabled (use 'tls: {verify_peer: true}'), see CVE-2020-13482 and https://github.com/igrigorik/em-http-request/issues/339 for details
```

 go away unless this is merged: https://github.com/igrigorik/em-http-request/pull/341

OR ```verify_peer: true``` is used.