### PR TITLE
Rescue Errno::ECONNRESET in shutdown phase

### DIFF
--- a/lib/billy/proxy.rb
+++ b/lib/billy/proxy.rb
@@ -62,7 +62,7 @@ module Billy
       s.close
       Billy.log(:info, "puffing-billy: Waiting for event machine to shutdown on port #{port}")
       s
-    rescue Errno::ECONNREFUSED, Errno::EADDRNOTAVAIL, Errno::ENETUNREACH
+    rescue Errno::ECONNREFUSED, Errno::EADDRNOTAVAIL, Errno::ENETUNREACH, Errno::ECONNRESET
       false
     end
 


### PR DESCRIPTION
While waiting for shutdown, the proxy attempts to connect to the event machine TCP socket in a loop until the connection fails to be made.

There's a small possibility here that the connection is established but the socket is closed by the remote before the poller closes it, in which case we get an `Errno::ECONNRESET` exception that isn't currently handled.

I think this error also indicates that we've shut down successfully, so this PR adds it to the existing rescue.

### Feedback

I _think_ it's safe to conclude that EM has shut down as a result of this error, but there might be other explanations for the reset; would we prefer to go round the loop again in this case and wait for one of the other errors?

Also, I didn't see an obvious place to add a test for this behaviour, and concluded that since it's a small addition to an existing rescue, that was fine. Does that sound reasonable?