### PR TITLE
Adapt puffing billing to newer versions selenium webdriver

### DIFF
--- a/lib/billy/browsers/capybara.rb
+++ b/lib/billy/browsers/capybara.rb
@@ -47,19 +47,24 @@ module Billy
 
       def self.register_selenium_driver
         ::Capybara.register_driver :selenium_billy do |app|
-          options = build_selenium_options_for_firefox
-          capabilities = Selenium::WebDriver::Remote::Capabilities.firefox(accept_insecure_certs: true)
+          capabilities = [
+            build_selenium_options_for_firefox,
+            Selenium::WebDriver::Remote::Capabilities.firefox(accept_insecure_certs: true)
+          ]
 
-          ::Capybara::Selenium::Driver.new(app, options: options, desired_capabilities: capabilities)
+          ::Capybara::Selenium::Driver.new(app, capabilities: capabilities)
         end
 
         ::Capybara.register_driver :selenium_headless_billy do |app|
           options = build_selenium_options_for_firefox.tap do |opts|
             opts.add_argument '-headless'
           end
-          capabilities = Selenium::WebDriver::Remote::Capabilities.firefox(accept_insecure_certs: true)
-          
-          ::Capybara::Selenium::Driver.new(app, options: options, desired_capabilities: capabilities)
+          capabilities = [
+            options,
+            Selenium::WebDriver::Remote::Capabilities.firefox(accept_insecure_certs: true)
+          ]
+
+          ::Capybara::Selenium::Driver.new(app, capabilities: capabilities)
         end
 
         ::Capybara.register_driver :selenium_chrome_billy do |app|
@@ -70,7 +75,7 @@ module Billy
           ::Capybara::Selenium::Driver.new(
             app,
             browser: :chrome,
-            options: options,
+            capabilities: options,
             clear_local_storage: true,
             clear_session_storage: true
           )
@@ -88,7 +93,7 @@ module Billy
           ::Capybara::Selenium::Driver.new(
             app,
             browser: :chrome,
-            options: options,
+            capabilities: options,
             clear_local_storage: true,
             clear_session_storage: true
           )
@@ -105,7 +110,6 @@ module Billy
 
       def self.build_selenium_options_for_firefox
         profile = Selenium::WebDriver::Firefox::Profile.new.tap do |prof|
-          prof.assume_untrusted_certificate_issuer = false
           prof.proxy = Selenium::WebDriver::Proxy.new(
             http: "#{Billy.proxy.host}:#{Billy.proxy.port}",
             ssl: "#{Billy.proxy.host}:#{Billy.proxy.port}")

--- a/puffing-billy.gemspec
+++ b/puffing-billy.gemspec
@@ -8,13 +8,12 @@ Gem::Specification.new do |gem|
   gem.summary       = 'Easy request stubs for browser tests.'
   gem.homepage      = 'https://github.com/oesmith/puffing-billy'
 
-  gem.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
-  gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+  gem.files         = %w[LICENSE CHANGELOG.md README.md] + Dir['lib/**/*.rb']
   gem.name          = 'puffing-billy'
   gem.require_paths = ['lib']
   gem.version       = Billy::VERSION
   gem.required_ruby_version = '>= 2.6.0'
+  gem.license       = 'MIT'
 
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'thin'
@@ -28,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rb-inotify'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'cucumber'
-  gem.add_development_dependency 'watir', '>= 7.0.0'
+  gem.add_development_dependency 'watir', '~> 7.1.0'
   gem.add_development_dependency 'webdrivers', '>= 5.0.0'
   gem.add_development_dependency 'webrick'
   gem.add_runtime_dependency 'addressable', '~> 2.5'


### PR DESCRIPTION
This PR introduces two changes, the first one is in the gemspec file where the gem generated included all files, but now it will require only the needed ones.
@oesmith could you confirm that this is correct? Do you need the binary to be included? You don't mention it in the README so I guess it is not for the gem.
![Screenshot 2022-01-04 at 09 20 20](https://user-images.githubusercontent.com/925961/148031081-928c1cbd-2e2e-4c0c-915b-ce2f570170bd.png)

Another change in the gemspec is to bump the minimum required version to 3.150.0 where `assume_untrusted_certificate_issuer` was [removed](https://github.com/SeleniumHQ/selenium/commit/e3541d6aa8d84fe6c673b984c96c07d1e161facc#diff-7ee189046cdbd95200c1e7f74f56b9ccde5f779876e7df363e44dd1be4f46915) from the firefox profile class.

The last change is in `lib/billy/browsers/capybara.rb`, where I removed `assume_untrusted_certificate_issuer` (I don't know what the alternative is) and also remove deprecation warnings to use `capabilities` param instead of `options` and `desired_capabilities`.
