### PR TITLE
Only calculate cache scope and key if request is cacheable for performance

### DIFF
--- a/lib/billy/cache.rb
+++ b/lib/billy/cache.rb
@@ -15,6 +15,8 @@ module Billy
     end
 
     def cached?(method, url, body)
+      return false unless Billy.config.cache
+
       # Only log the key the first time it's looked up (in this method)
       key = key(method, url, body, true)
       !@cache[key].nil? || persisted?(key)

--- a/lib/billy/handlers/proxy_handler.rb
+++ b/lib/billy/handlers/proxy_handler.rb
@@ -25,9 +25,6 @@ module Billy
                                  port: Billy.config.proxied_request_port }} )
         end
 
-        cache_scope = Billy::Cache.instance.scope
-        cache_key = Billy::Cache.instance.key(method.downcase, url, body)
-
         req = EventMachine::HttpRequest.new(url, opts)
         req = req.send(method.downcase, build_request_options(url, headers, body))
 
@@ -47,6 +44,9 @@ module Billy
           end
 
           if cacheable?(url, response[:headers], response[:status])
+            cache_scope = Billy::Cache.instance.scope
+            cache_key = Billy::Cache.instance.key(method.downcase, url, body)
+
             Billy::Cache.instance.store(
               cache_key,
               cache_scope,


### PR DESCRIPTION
While debugging general performance/reliability issues in our test suite, I thought I would see what effect disabling Billy's cache had on our test suite. (We don't intentionally use it.) 

So I configured with `cache = false`, but was still surprised to see log entries about calculated cache keys for requests.

It appears ProxyHandler was unconditionally calculating the scope and key, the latter of which seems expensive to perform. 

Admittedly, my understanding of the overall system is minimal, but it _seems_ like this change wouldn't have any unwanted side effects, and skip unused method calls for users who have `cache = false`. 