### PR TITLE
Adds a configurable Cuprite driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Capybara.javascript_driver = :selenium_billy # Uses Firefox
 # Capybara.javascript_driver = :apparition_billy
 # Capybara.javascript_driver = :webkit_billy
 # Capybara.javascript_driver = :poltergeist_billy
+# Capybara.javascript_driver = :cuprite_billy
 ```
 
 > __Note__: `:poltergeist_billy` doesn't support proxying any localhosts, so you must use
@@ -153,6 +154,20 @@ And /^a stub for google$/ do
   expect(@browser.text).to eq("I'm not Google!")
 end
 ```
+
+### Setup remote Chrome
+
+In the case you are using a Chrome instance, running on another machine, or in
+another Docker container, you need to :
+* Fix the Billy proxy host and port
+* Passes the `--proxy-server=<billy host>:<billy port>`
+
+#### WebSockets
+
+Puffing billy doesn't support websockets, so if you are using them,
+or ActionCable for the Ruby On Rails developers, you can tell Chrome to bypass
+the proxy for websockets by adding the flag `--proxy-bypass-list=ws://*` to
+your remote chrome intance or Docker container.
 
 ## Minitest Usage
 

--- a/lib/billy/browsers/capybara.rb
+++ b/lib/billy/browsers/capybara.rb
@@ -8,7 +8,8 @@ module Billy
         poltergeist: 'capybara/poltergeist',
         webkit: 'capybara/webkit',
         selenium: 'selenium/webdriver',
-        apparition: 'capybara/apparition'
+        apparition: 'capybara/apparition',
+        cuprite: 'capybara/cuprite'
       }
 
       def self.register_drivers
@@ -103,6 +104,20 @@ module Billy
       def self.register_apparition_driver
         ::Capybara.register_driver :apparition_billy do |app|
           ::Capybara::Apparition::Driver.new(app, ignore_https_errors: true).tap do |driver|
+            driver.set_proxy(Billy.proxy.host, Billy.proxy.port)
+          end
+        end
+      end
+
+      def self.register_cuprite_driver
+        driver_otions = {
+          browser_options: {
+            'ignore-certificate-errors' => nil
+          }
+        }.deep_merge(Billy.config.cuprite_options)
+
+        ::Capybara.register_driver :cuprite_billy do |app|
+          ::Capybara::Cuprite::Driver.new(app, **driver_otions).tap do |driver|
             driver.set_proxy(Billy.proxy.host, Billy.proxy.port)
           end
         end

--- a/lib/billy/config.rb
+++ b/lib/billy/config.rb
@@ -11,7 +11,8 @@ module Billy
                   :non_whitelisted_requests_disabled, :cache_path, :certs_path, :verify_peer, :proxy_host, :proxy_port, :proxied_request_inactivity_timeout,
                   :proxied_request_connect_timeout, :dynamic_jsonp, :dynamic_jsonp_keys, :dynamic_jsonp_callback_name, :merge_cached_responses_whitelist,
                   :strip_query_params, :proxied_request_host, :proxied_request_port, :cache_request_body_methods, :after_cache_handles_request,
-                  :cache_simulates_network_delays, :cache_simulates_network_delay_time, :record_requests, :record_stub_requests, :use_ignore_params, :before_handle_request
+                  :cache_simulates_network_delays, :cache_simulates_network_delay_time, :record_requests, :record_stub_requests, :use_ignore_params,
+                  :before_handle_request, :cuprite_options
 
     def initialize
       @logger = defined?(Rails) ? Rails.logger : Logger.new(STDOUT)
@@ -53,6 +54,7 @@ module Billy
       @record_stub_requests = false
       @use_ignore_params = true
       @before_handle_request = nil
+      @cuprite_options = {}
     end
   end
 


### PR DESCRIPTION
This PR adds support for a configurable Cuprite driver.

What I mean is that it allows passing additional flags to the driver like that :

```ruby
# Some code here to build the `remote_chrome` variable and the `REMOTE_CHROME_URL` constant.

remote_options = remote_chrome ? { url: REMOTE_CHROME_URL } : {}

Billy.configure do |c|
  c.cuprite_options = {
    browser_options: remote_chrome ? { 'no-sandbox' => nil } : {},
    inspector: true,
    js_errors: true,
    # See features/support/download_helpers.rb
    save_path: File.join(Capybara.save_path, 'downloads'),
    window_size: [810, 1080]
  }.merge(remote_options)

  c.cache = true
  # ...
end

require 'billy/capybara/cucumber'

Capybara.default_driver =
    Capybara.javascript_driver =
      Capybara.current_driver = :cuprite_billy
```

This PR also update the `README.md` file in order to explain how to configure a remote Chrome with nice tip about ActionCable taken from [#252](https://github.com/oesmith/puffing-billy/issues/252#issuecomment-594478533).