### PR TITLE
Replace deprecated headless! `Selenium::WebDriver::Chrome::Options`

### DIFF
--- a/lib/billy/browsers/capybara.rb
+++ b/lib/billy/browsers/capybara.rb
@@ -84,7 +84,7 @@ module Billy
 
         ::Capybara.register_driver :selenium_chrome_headless_billy do |app|
             options = Selenium::WebDriver::Chrome::Options.new
-            options.headless!
+            options.add_argument('--headless=new')
             options.add_argument('--enable-features=NetworkService,NetworkServiceInProcess')
             options.add_argument('--ignore-certificate-errors')
             options.add_argument("--proxy-server=#{Billy.proxy.host}:#{Billy.proxy.port}")


### PR DESCRIPTION
The `selenium-webdriver` `headless!` method has been deprecated since version 4.8 (https://github.com/SeleniumHQ/selenium/blob/trunk/rb/CHANGES#L114) and on version 4.11.0 it got removed (https://github.com/SeleniumHQ/selenium/pull/12417)

According to the documentation https://www.selenium.dev/blog/2023/headless-is-going-away/, the new way to run a headless browser is with the `--headless=new` argument.

Fixes https://github.com/oesmith/puffing-billy/issues/332