### PR TITLE
Drop Ruby 2.6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2']
 
     steps:
     - uses: actions/checkout@v2

--- a/puffing-billy.gemspec
+++ b/puffing-billy.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.name          = 'puffing-billy'
   gem.require_paths = ['lib']
   gem.version       = Billy::VERSION
-  gem.required_ruby_version = '>= 2.6.0'
+  gem.required_ruby_version = '>= 2.7.0'
   gem.license       = 'MIT'
 
   gem.add_development_dependency 'rspec'


### PR DESCRIPTION
Ruby 2.6 has reached EOL since 2022-04-12. To keep `puffing-billy` moving forward I believe dropping support to EOL versions of Ruby will be necessary.