### PR TITLE
Use :options argument instead of :capabilities

### DIFF
--- a/lib/billy/browsers/capybara.rb
+++ b/lib/billy/browsers/capybara.rb
@@ -76,7 +76,7 @@ module Billy
           ::Capybara::Selenium::Driver.new(
             app,
             browser: :chrome,
-            capabilities: options,
+            options: options,
             clear_local_storage: true,
             clear_session_storage: true
           )
@@ -94,7 +94,7 @@ module Billy
           ::Capybara::Selenium::Driver.new(
             app,
             browser: :chrome,
-            capabilities: options,
+            options: options,
             clear_local_storage: true,
             clear_session_storage: true
           )


### PR DESCRIPTION
Fix `selenium-webdriver` `capabilities` deprecation warning. In the CI at the moment at we have the following log:

```
Randomized with seed 31709
........................2023-08-27 21:24:50 WARN Selenium [:capabilities] [DEPRECATION] The :capabilities parameter for Selenium::WebDriver::Chrome::Driver is deprecated. Use :options argument with an instance of Selenium::WebDriver::Chrome::Driver instead. 
................................................................................................*...................................................................................................................................................
```

This should fix this warning.

