### PR TITLE
Update CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['3.1', '3.2', '3.3', head]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/spec/features/examples/intercept_request_spec.rb
+++ b/spec/features/examples/intercept_request_spec.rb
@@ -7,7 +7,7 @@ describe 'intercept request example', type: :feature, js: true do
   end
 
   it 'should intercept a GET request directly' do
-    stub = proxy.stub('http://example.com/').and_return(
+    stub = proxy.stub('https://example.com:443/').and_return(
       headers: { 'Access-Control-Allow-Origin' => '*' },
       code: 200
     )


### PR DESCRIPTION
As #342 seems to got stuck. Here's a new attempt:

* remove unsupported Ruby Versions (2.7 and 3.0)
* add Ruby head
* use latest checkout action version