### PR TITLE
Fix: handle deprecation warning - add unary operator to mutable string

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.1', '3.2', '3.3', head]
+        ruby-version: ['3.1', '3.2', '3.3', '3.4', head]
 
     steps:
     - uses: actions/checkout@v4

--- a/lib/billy/proxy_connection.rb
+++ b/lib/billy/proxy_connection.rb
@@ -22,7 +22,7 @@ module Billy
 
     def on_message_begin
       @headers = nil
-      @body = ''
+      @body = +''
     end
 
     def on_headers_complete(headers)


### PR DESCRIPTION
Add unary operator to mutable string.

This avoids deprecation warnings when running against ruby 3.4.1 and prepares for later versions (4.0) that will default to `# frozen_string_literal: true`.

Deprecation warning:
```sh
gems/puffing-billy-4.0.0/lib/billy/proxy_connection.rb:33: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```

Example CI with deprecation warnings:
https://app.circleci.com/pipelines/github/ministryofjustice/laa-apply-for-legal-aid/32282/workflows/b137f673-cb4e-4f21-a307-86050bde6e87/jobs/168908/parallel-runs/0?filterBy=ALL