### PR TITLE
Guard Proxy#stop against already-stopped EventMachine reactor

### DIFF
--- a/lib/billy/proxy.rb
+++ b/lib/billy/proxy.rb
@@ -25,6 +25,7 @@ module Billy
 
     def stop
       return if @signature.nil?
+      return unless EM.reactor_running?
 
       server_port = port
       EM.stop

--- a/spec/lib/proxy_spec.rb
+++ b/spec/lib/proxy_spec.rb
@@ -319,6 +319,43 @@ shared_examples_for 'a cache' do
   end
 end
 
+describe Billy::Proxy, '#stop' do
+  let(:proxy) { Billy::Proxy.new }
+
+  context 'when signature is nil' do
+    it 'returns early without calling EM.stop' do
+      expect(EM).not_to receive(:reactor_running?)
+      expect(EM).not_to receive(:stop)
+      proxy.stop
+    end
+  end
+
+  context 'when reactor is not running' do
+    before { proxy.instance_variable_set(:@signature, 'fake-sig') }
+
+    it 'returns early without calling EM.stop' do
+      allow(EM).to receive(:reactor_running?).and_return(false)
+      expect(EM).not_to receive(:stop)
+      proxy.stop
+    end
+  end
+
+  context 'when reactor is running' do
+    before do
+      proxy.instance_variable_set(:@signature, 'fake-sig')
+      allow(EM).to receive(:reactor_running?).and_return(true)
+      allow(EM).to receive(:get_sockname).and_return(Socket.sockaddr_in(12345, '127.0.0.1'))
+      allow(EM).to receive(:stop)
+      allow(proxy).to receive(:wait_for_server_shutdown!)
+    end
+
+    it 'stops the reactor' do
+      proxy.stop
+      expect(EM).to have_received(:stop)
+    end
+  end
+end
+
 describe Billy::Proxy do
   before do
     # Adding non-valid Faraday options throw an error: https://github.com/arsduo/koala/pull/311


### PR DESCRIPTION
## Summary
- Adds `EM.reactor_running?` guard in `Proxy#stop` to prevent `RuntimeError: eventmachine not initialized` when the reactor has already stopped

## Problem
When EventMachine has already stopped (e.g. during RSpec `after(:suite)` teardown), calling `EM.get_sockname` (via `port`) or `EM.stop` raises `RuntimeError: eventmachine not initialized`. This causes test suites to exit non-zero despite all tests passing ("1 error occurred outside of examples").

## Solution
```ruby
def stop
  return if @signature.nil?
  return unless EM.reactor_running?  # new guard

  server_port = port
  EM.stop
  wait_for_server_shutdown! server_port
end
```

The existing `@signature.nil?` check only guards against a proxy that was never started. It doesn't cover the case where EventMachine's reactor loop has already been shut down by another mechanism.

Fixes #253

## Verification
- `bundle exec rspec spec/lib/proxy_spec.rb` — all examples pass, 0 failures
- Confirmed the fix resolves the `eventmachine not initialized` crash in a production Rails app with 935+ messaging specs using puffing-billy 4.0.0